### PR TITLE
Added force_new option to the resource

### DIFF
--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -72,6 +72,13 @@ func resourceRestApi() *schema.Resource {
         Description: "After data from the API server is read, this map will include k/v pairs usable in other terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).",
 	Computed:    true,
       },
+      "force_new": &schema.Schema{
+        Type: schema.TypeList,
+        Elem: &schema.Schema{Type: schema.TypeString},
+        Optional: true,
+        ForceNew: true,
+        Description: "Any changes to these values will result in recreating the resource instead of updating.",
+      },
     }, /* End schema */
 
   }


### PR DESCRIPTION
example:
```terraform
locals {
  user_data = {
    user = {
      email = "${var.user_mail}"
      password = "${var.password}"
    }
  }
}

resource "restapi_object" "robot_user" {
  path         = "/users"
  data         = "${jsonencode(local.user_data)}"
  force_new = ["${var.user_mail}"]

  debug = true
}
```
`User` object has a restriction set on API that once set, email can not be changed. Currently modifying `user_mail` will result in a **PUT** request which will fail with a validation error. So we are introducing a field force_new which will force the resource to be recreated instead of editing it.

Admittedly this is a poor man's facsimile. Presently this will use stored `var.user_mail` value instead of actual resource state. Ideally we should be taking an array of string selectors (similar in syntax to id_attribute, ex: ["user/email"]) and compare the corresponding values from fetched real state and desired state.