### PR TITLE
Passing tests

### DIFF
--- a/fakeserver/fakeserver.go
+++ b/fakeserver/fakeserver.go
@@ -1,191 +1,211 @@
 package fakeserver
 
 import (
-  "log"
-  "net/http"
-  "time"
-  "encoding/json"
-  "fmt"
-  "io/ioutil"
-  "strings"
-  "os"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
 )
 
 type fakeserver struct {
-  server   *http.Server
-  objects  map[string]map[string]interface{}
-  debug    bool
-  running  bool
+	server  *http.Server
+	objects map[string]map[string]interface{}
+	debug   bool
+	running bool
 }
 
 func NewFakeServer(i_port int, i_objects map[string]map[string]interface{}, i_start bool, i_debug bool, dir string) *fakeserver {
-  serverMux := http.NewServeMux()
+	serverMux := http.NewServeMux()
 
-  svr := &fakeserver{
-    debug: i_debug,
-    objects: i_objects,
-    running: false,
-  }
-
-  //If we were passed an argument for where to serve /static from...
-  if dir != "" {
-    _, err := os.Stat(dir)
-    if err == nil {
-      if svr.debug { log.Printf("fakeserver.go: Will serve static files in '%s' under /static path", dir) }
-      serverMux.Handle("/static/", http.StripPrefix("/static/", http.FileServer( http.Dir(dir))))
-    } else {
-      log.Printf("fakeserver.go: WARNING: Not serving /static because directory '%s' does not exist", dir)
-    }
-  }
-
-  serverMux.HandleFunc("/api/", svr.handle_api_object)
-
-  api_object_server := &http.Server{
-    Addr: fmt.Sprintf("127.0.0.1:%d", i_port),
-    Handler: serverMux,
-  }
-
-  svr.server = api_object_server
-
-  if i_start { svr.StartInBackground() }
-  if svr.debug { log.Printf("fakeserver.go: Set up fakeserver: port=%d, debug=%t\n", i_port, svr.debug) }
-
-  return svr
-}
-
-func(svr *fakeserver)StartInBackground() {
-  go svr.server.ListenAndServe()
-
-  /* Let the server start */
-  time.Sleep(1 * time.Second)
-  svr.running = true
-}
-
-func(svr *fakeserver)Shutdown() {
-  svr.server.Close()
-  svr.running = false
-}
-
-func(svr *fakeserver)Running() bool {
-  return svr.running
-}
-
-func(svr *fakeserver)GetServer() *http.Server {
-  return svr.server
-}
-
-func (svr *fakeserver)handle_api_object (w http.ResponseWriter, r *http.Request) {
-  var obj map[string]interface{}
-  var id string
-  var ok bool
-
-  /* Assume this will never fail */
-  b, _ := ioutil.ReadAll(r.Body)
-
-  if svr.debug {
-    log.Printf("fakeserver.go: Recieved request: %+v\n", r)
-    log.Printf("fakeserver.go: Headers:\n")
-    for name, headers := range r.Header {
-      name = strings.ToLower(name)
-      for _, h := range headers {
-      log.Printf("fakeserver.go:  %v: %v", name, h)
-      }
-    }
-    log.Printf("fakeserver.go: BODY: %s\n", string(b))
-    log.Printf("fakeserver.go: IDs and objects:\n")
-    for id, obj := range svr.objects {
-      log.Printf("  %s: %+v\n", id, obj)
-    }
-  }
-
-  path := r.URL.EscapedPath()
-  parts := strings.Split(path, "/")
-  if svr.debug {
-    log.Printf("fakeserver.go: Request received: %s %s\n", r.Method, path)
-    log.Printf("fakeserver.go: Split request up into %d parts: %v\n", len(parts), parts)
-    if r.URL.RawQuery != "" {
-      log.Printf("fakeserver.go: Query string: %s\n", r.URL.RawQuery)
-    }
-  }
-  /* If it was a valid request, there will be three parts
-     and the ID will exist */
-  if len(parts) == 4 {
-    id = parts[3]
-    obj, ok = svr.objects[id];
-    if svr.debug { log.Printf("fakeserver.go: Detected ID %s (exists: %t, method: %s)", id, ok, r.Method) }
-
-    /* Make sure the object requested exists unless it's being created */
-    if r.Method != "POST" && !ok {
-      http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
-      return
-    }
-  } else if path != "/api/objects" {
-    /* How did something get to this handler with the wrong number of args??? */
-    if svr.debug { log.Printf("fakeserver.go: Bad request - got to /api/objects without the right number of args") }
-    http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-    return
-  } else if path == "/api/objects" && r.Method == "GET" {
-    result := make([]map[string]interface{}, 0)
-    for _, hash := range svr.objects {
-      result = append(result, hash)
-    }
-    b, _ := json.Marshal(result)
-    w.Write(b)
-    return
-  }
-
-  if r.Method == "DELETE" {
-    /* Get rid of this one */
-    delete(svr.objects, id)
-    if svr.debug { log.Printf("fakeserver.go: Object deleted.\n") }
-    return
-  }
-  /* if data was sent, parse the data */
-  if string(b) != "" {
-    if svr.debug { log.Printf("fakeserver.go: data sent - unmarshalling from JSON: %s\n", string(b)) }
-
-    err := json.Unmarshal(b, &obj)
-    if err != nil {
-      /* Failure goes back to the user as a 500. Log data here for
-         debugging (which shouldn't ever fail!) */
-      log.Fatalf("fakeserver.go: Unmarshal of request failed: %s\n", err);
-      log.Fatalf("\nBEGIN passed data:\n%s\nEND passed data.", string(b));
-      http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-      return
-    } else {
-      /* In the case of POST above, id is not yet known - set it here */
-      if id == "" {
-	if val, ok := obj["id"]; ok {
-          id = fmt.Sprintf("%v", val)
-	} else if val, ok := obj["Id"]; ok {
-          id = fmt.Sprintf("%v", val)
-	} else if val, ok := obj["ID"]; ok {
-          id = fmt.Sprintf("%v", val)
-	} else {
-          if svr.debug { log.Printf("fakeserver.go: Bad request - POST to /api/objects without id field") }
-          http.Error(w, "POST sent with no id field in the data. Cannot persist this!", http.StatusBadRequest)
-	  return
+	svr := &fakeserver{
+		debug:   i_debug,
+		objects: i_objects,
+		running: false,
 	}
-      }
 
-      /* Overwrite our stored test object */
-      if svr.debug { log.Printf("fakeserver.go: Overwriting %s with new data:%+v\n", id, obj) }
-      svr.objects[id] = obj
+	//If we were passed an argument for where to serve /static from...
+	if dir != "" {
+		_, err := os.Stat(dir)
+		if err == nil {
+			if svr.debug {
+				log.Printf("fakeserver.go: Will serve static files in '%s' under /static path", dir)
+			}
+			serverMux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(dir))))
+		} else {
+			log.Printf("fakeserver.go: WARNING: Not serving /static because directory '%s' does not exist", dir)
+		}
+	}
 
-      /* Coax the data we were sent back to JSON and send it to the user */
-      b, _ := json.Marshal(obj)
-      w.Write(b)
-      return
-    }
-  } else {
-    /* No data was sent... must be just a retrieval */
-    if svr.debug { log.Printf("fakeserver.go: Returning object.\n") }
-    b, _ := json.Marshal(obj)
-    w.Write(b)
-    return
-  }
+	serverMux.HandleFunc("/api/", svr.handle_api_object)
 
-  /* All cases by now should have already returned... something wasn't handled */
-  http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-  return
+	api_object_server := &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", i_port),
+		Handler: serverMux,
+	}
+
+	svr.server = api_object_server
+
+	if i_start {
+		svr.StartInBackground()
+	}
+	if svr.debug {
+		log.Printf("fakeserver.go: Set up fakeserver: port=%d, debug=%t\n", i_port, svr.debug)
+	}
+
+	return svr
+}
+
+func (svr *fakeserver) StartInBackground() {
+	go svr.server.ListenAndServe()
+
+	/* Let the server start */
+	time.Sleep(1 * time.Second)
+	svr.running = true
+}
+
+func (svr *fakeserver) Shutdown() {
+	svr.server.Close()
+	svr.running = false
+}
+
+func (svr *fakeserver) Running() bool {
+	return svr.running
+}
+
+func (svr *fakeserver) GetServer() *http.Server {
+	return svr.server
+}
+
+func (svr *fakeserver) handle_api_object(w http.ResponseWriter, r *http.Request) {
+	var obj map[string]interface{}
+	var id string
+	var ok bool
+
+	/* Assume this will never fail */
+	b, _ := ioutil.ReadAll(r.Body)
+
+	if svr.debug {
+		log.Printf("fakeserver.go: Recieved request: %+v\n", r)
+		log.Printf("fakeserver.go: Headers:\n")
+		for name, headers := range r.Header {
+			name = strings.ToLower(name)
+			for _, h := range headers {
+				log.Printf("fakeserver.go:  %v: %v", name, h)
+			}
+		}
+		log.Printf("fakeserver.go: BODY: %s\n", string(b))
+		log.Printf("fakeserver.go: IDs and objects:\n")
+		for id, obj := range svr.objects {
+			log.Printf("  %s: %+v\n", id, obj)
+		}
+	}
+
+	path := r.URL.EscapedPath()
+	parts := strings.Split(path, "/")
+	if svr.debug {
+		log.Printf("fakeserver.go: Request received: %s %s\n", r.Method, path)
+		log.Printf("fakeserver.go: Split request up into %d parts: %v\n", len(parts), parts)
+		if r.URL.RawQuery != "" {
+			log.Printf("fakeserver.go: Query string: %s\n", r.URL.RawQuery)
+		}
+	}
+	/* If it was a valid request, there will be three parts
+	   and the ID will exist */
+	if len(parts) == 4 {
+		id = parts[3]
+		obj, ok = svr.objects[id]
+		if svr.debug {
+			log.Printf("fakeserver.go: Detected ID %s (exists: %t, method: %s)", id, ok, r.Method)
+		}
+
+		/* Make sure the object requested exists unless it's being created */
+		if r.Method != "POST" && !ok {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+	} else if path != "/api/objects" {
+		/* How did something get to this handler with the wrong number of args??? */
+		if svr.debug {
+			log.Printf("fakeserver.go: Bad request - got to /api/objects without the right number of args")
+		}
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	} else if path == "/api/objects" && r.Method == "GET" {
+		result := make([]map[string]interface{}, 0)
+		for _, hash := range svr.objects {
+			result = append(result, hash)
+		}
+		b, _ := json.Marshal(result)
+		w.Write(b)
+		return
+	}
+
+	if r.Method == "DELETE" {
+		/* Get rid of this one */
+		delete(svr.objects, id)
+		if svr.debug {
+			log.Printf("fakeserver.go: Object deleted.\n")
+		}
+		return
+	}
+	/* if data was sent, parse the data */
+	if string(b) != "" {
+		if svr.debug {
+			log.Printf("fakeserver.go: data sent - unmarshalling from JSON: %s\n", string(b))
+		}
+
+		err := json.Unmarshal(b, &obj)
+		if err != nil {
+			/* Failure goes back to the user as a 500. Log data here for
+			   debugging (which shouldn't ever fail!) */
+			log.Fatalf("fakeserver.go: Unmarshal of request failed: %s\n", err)
+			log.Fatalf("\nBEGIN passed data:\n%s\nEND passed data.", string(b))
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		} else {
+			/* In the case of POST above, id is not yet known - set it here */
+			if id == "" {
+				if val, ok := obj["id"]; ok {
+					id = fmt.Sprintf("%v", val)
+				} else if val, ok := obj["Id"]; ok {
+					id = fmt.Sprintf("%v", val)
+				} else if val, ok := obj["ID"]; ok {
+					id = fmt.Sprintf("%v", val)
+				} else {
+					if svr.debug {
+						log.Printf("fakeserver.go: Bad request - POST to /api/objects without id field")
+					}
+					http.Error(w, "POST sent with no id field in the data. Cannot persist this!", http.StatusBadRequest)
+					return
+				}
+			}
+
+			/* Overwrite our stored test object */
+			if svr.debug {
+				log.Printf("fakeserver.go: Overwriting %s with new data:%+v\n", id, obj)
+			}
+			svr.objects[id] = obj
+
+			/* Coax the data we were sent back to JSON and send it to the user */
+			b, _ := json.Marshal(obj)
+			w.Write(b)
+			return
+		}
+	} else {
+		/* No data was sent... must be just a retrieval */
+		if svr.debug {
+			log.Printf("fakeserver.go: Returning object.\n")
+		}
+		b, _ := json.Marshal(obj)
+		w.Write(b)
+		return
+	}
+
+	/* All cases by now should have already returned... something wasn't handled */
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	return
 }

--- a/fakeservercli/main.go
+++ b/fakeservercli/main.go
@@ -1,31 +1,30 @@
 package main
 
 import (
-  "os"
-  "flag"
-  "fmt"
-  fakeserver "github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"flag"
+	"fmt"
+	fakeserver "github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"os"
 )
 
-
 func main() {
-  api_server_objects := make(map[string]map[string]interface{})
+	api_server_objects := make(map[string]map[string]interface{})
 
-  port := flag.Int("port", 8080, "The port fakeserver will listen on")
-  debug := flag.Bool("debug", false, "Enable debug output of the server")
-  static_dir := flag.String("static_dir", "", "Serve static content from this directory")
+	port := flag.Int("port", 8080, "The port fakeserver will listen on")
+	debug := flag.Bool("debug", false, "Enable debug output of the server")
+	static_dir := flag.String("static_dir", "", "Serve static content from this directory")
 
-  flag.Parse()
+	flag.Parse()
 
-  svr := fakeserver.NewFakeServer(*port, api_server_objects, false, *debug, *static_dir)
+	svr := fakeserver.NewFakeServer(*port, api_server_objects, false, *debug, *static_dir)
 
-  fmt.Printf("Starting server on port %d...\n", *port)
-  fmt.Println("Objects are at /api/objects/{id}")
+	fmt.Printf("Starting server on port %d...\n", *port)
+	fmt.Println("Objects are at /api/objects/{id}")
 
-  internal_server := svr.GetServer()
-  err := internal_server.ListenAndServe()
-  if nil != err {
-    fmt.Printf("Error with the internal TCP server: %s", err)
-    os.Exit(1)
-  }
+	internal_server := svr.GetServer()
+	err := internal_server.ListenAndServe()
+	if nil != err {
+		fmt.Printf("Error with the internal TCP server: %s", err)
+		os.Exit(1)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-  "github.com/hashicorp/terraform/plugin"
-  "github.com/hashicorp/terraform/terraform"
-  "github.com/Mastercard/terraform-provider-restapi/restapi"
+	"github.com/Mastercard/terraform-provider-restapi/restapi"
+	"github.com/hashicorp/terraform/plugin"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
-  plugin.Serve(&plugin.ServeOpts{
-    ProviderFunc: func() terraform.ResourceProvider {
-      return restapi.Provider()
-    },
-  })
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: func() terraform.ResourceProvider {
+			return restapi.Provider()
+		},
+	})
 }

--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -1,212 +1,215 @@
 package restapi
 
 import (
-  "log"
-  "net/http"
-  "net/http/cookiejar"
-  "crypto/tls"
-  "errors"
-  "fmt"
-  "io/ioutil"
-  "strings"
-  "bytes"
-  "time"
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"time"
 )
 
 type api_client struct {
-  http_client           *http.Client
-  uri                   string
-  insecure              bool
-  username              string
-  password              string
-  headers               map[string]string
-  redirects             int
-  timeout               int
-  id_attribute          string
-  copy_keys             []string
-  write_returns_object  bool
-  create_returns_object bool
-  xssi_prefix           string
-  debug                 bool
+	http_client           *http.Client
+	uri                   string
+	insecure              bool
+	username              string
+	password              string
+	headers               map[string]string
+	redirects             int
+	timeout               int
+	id_attribute          string
+	copy_keys             []string
+	write_returns_object  bool
+	create_returns_object bool
+	xssi_prefix           string
+	debug                 bool
 }
 
-
 // Make a new api client for RESTful calls
-func NewAPIClient (i_uri string, i_insecure bool, i_username string, i_password string, i_headers map[string]string, i_use_cookies bool, i_timeout int, i_id_attribute string, i_copy_keys []string, i_wro bool, i_cro bool, i_xssi_prefix string, i_debug bool) (*api_client, error) {
-  if i_debug {
-    log.Printf("api_client.go: Constructing debug api_client\n")
-  }
+func NewAPIClient(i_uri string, i_insecure bool, i_username string, i_password string, i_headers map[string]string, i_use_cookies bool, i_timeout int, i_id_attribute string, i_copy_keys []string, i_wro bool, i_cro bool, i_xssi_prefix string, i_debug bool) (*api_client, error) {
+	if i_debug {
+		log.Printf("api_client.go: Constructing debug api_client\n")
+	}
 
-  if i_uri == "" {
-    return nil, errors.New("uri must be set to construct an API client")
-  }
+	if i_uri == "" {
+		return nil, errors.New("uri must be set to construct an API client")
+	}
 
-  /* Sane default */
-  if i_id_attribute == "" {
-    i_id_attribute = "id"
-  }
+	/* Sane default */
+	if i_id_attribute == "" {
+		i_id_attribute = "id"
+	}
 
-  /* Remove any trailing slashes since we will append
-     to this URL with our own root-prefixed location */
-  if strings.HasSuffix(i_uri, "/") {
-    i_uri = i_uri[:len(i_uri)-1]
-  }
+	/* Remove any trailing slashes since we will append
+	   to this URL with our own root-prefixed location */
+	if strings.HasSuffix(i_uri, "/") {
+		i_uri = i_uri[:len(i_uri)-1]
+	}
 
-  /* Disable TLS verification if requested */
-  tr := &http.Transport{
-    TLSClientConfig: &tls.Config{InsecureSkipVerify: i_insecure},
-  }
+	/* Disable TLS verification if requested */
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: i_insecure},
+	}
 
-  var cookieJar http.CookieJar
+	var cookieJar http.CookieJar
 
-  if i_use_cookies {
-    cookieJar, _ = cookiejar.New(nil)
-  }
+	if i_use_cookies {
+		cookieJar, _ = cookiejar.New(nil)
+	}
 
-  client := api_client{
-    http_client: &http.Client{
-      Timeout: time.Second * time.Duration(i_timeout),
-      Transport: tr,
-      Jar: cookieJar,
-      },
-    uri: i_uri,
-    insecure: i_insecure,
-    username: i_username,
-    password: i_password,
-    headers: i_headers,
-    id_attribute: i_id_attribute,
-    copy_keys: i_copy_keys,
-    write_returns_object: i_wro,
-    create_returns_object: i_cro,
-    redirects: 5,
-    xssi_prefix: i_xssi_prefix,
-    debug: i_debug,
-  }
+	client := api_client{
+		http_client: &http.Client{
+			Timeout:   time.Second * time.Duration(i_timeout),
+			Transport: tr,
+			Jar:       cookieJar,
+		},
+		uri:                   i_uri,
+		insecure:              i_insecure,
+		username:              i_username,
+		password:              i_password,
+		headers:               i_headers,
+		id_attribute:          i_id_attribute,
+		copy_keys:             i_copy_keys,
+		write_returns_object:  i_wro,
+		create_returns_object: i_cro,
+		redirects:             5,
+		xssi_prefix:           i_xssi_prefix,
+		debug:                 i_debug,
+	}
 
-  if i_debug {
-    log.Printf("api_client.go: Constructed object:\n%s", client.toString())
-  }
-  return &client, nil
+	if i_debug {
+		log.Printf("api_client.go: Constructed object:\n%s", client.toString())
+	}
+	return &client, nil
 }
 
 // Convert the important bits about this object to string representation
 // This is useful for debugging.
 func (obj *api_client) toString() string {
-  var buffer bytes.Buffer
-  buffer.WriteString(fmt.Sprintf("uri: %s\n", obj.uri))
-  buffer.WriteString(fmt.Sprintf("insecure: %t\n", obj.insecure))
-  buffer.WriteString(fmt.Sprintf("username: %s\n", obj.username))
-  buffer.WriteString(fmt.Sprintf("password: %s\n", obj.password))
-  buffer.WriteString(fmt.Sprintf("id_attribute: %s\n", obj.id_attribute))
-  buffer.WriteString(fmt.Sprintf("write_returns_object: %t\n", obj.write_returns_object))
-  buffer.WriteString(fmt.Sprintf("create_returns_object: %t\n", obj.create_returns_object))
-  buffer.WriteString(fmt.Sprintf("headers:\n"))
-  for k,v := range obj.headers {
-    buffer.WriteString(fmt.Sprintf("  %s: %s\n", k,v))
-  }
-  for _, n := range obj.copy_keys {
-    buffer.WriteString(fmt.Sprintf("  %s", n))
-  }
-  return buffer.String()
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("uri: %s\n", obj.uri))
+	buffer.WriteString(fmt.Sprintf("insecure: %t\n", obj.insecure))
+	buffer.WriteString(fmt.Sprintf("username: %s\n", obj.username))
+	buffer.WriteString(fmt.Sprintf("password: %s\n", obj.password))
+	buffer.WriteString(fmt.Sprintf("id_attribute: %s\n", obj.id_attribute))
+	buffer.WriteString(fmt.Sprintf("write_returns_object: %t\n", obj.write_returns_object))
+	buffer.WriteString(fmt.Sprintf("create_returns_object: %t\n", obj.create_returns_object))
+	buffer.WriteString(fmt.Sprintf("headers:\n"))
+	for k, v := range obj.headers {
+		buffer.WriteString(fmt.Sprintf("  %s: %s\n", k, v))
+	}
+	for _, n := range obj.copy_keys {
+		buffer.WriteString(fmt.Sprintf("  %s", n))
+	}
+	return buffer.String()
 }
 
 /* Helper function that handles sending/receiving and handling
    of HTTP data in and out.
    TODO: Handle redirects */
-func (client *api_client) send_request (method string, path string, data string) (string, error) {
-  full_uri := client.uri + path
-  var req *http.Request
-  var err error
+func (client *api_client) send_request(method string, path string, data string) (string, error) {
+	full_uri := client.uri + path
+	var req *http.Request
+	var err error
 
-  if client.debug {
-    log.Printf("api_client.go: method='%s', path='%s', full uri (derived)='%s', data='%s'\n", method, path, full_uri, data)
-  }
+	if client.debug {
+		log.Printf("api_client.go: method='%s', path='%s', full uri (derived)='%s', data='%s'\n", method, path, full_uri, data)
+	}
 
-  buffer := bytes.NewBuffer([]byte(data))
+	buffer := bytes.NewBuffer([]byte(data))
 
-  if data == "" {
-    req, err = http.NewRequest(method, full_uri, nil)
-  } else {
-    req, err = http.NewRequest(method, full_uri, buffer)
+	if data == "" {
+		req, err = http.NewRequest(method, full_uri, nil)
+	} else {
+		req, err = http.NewRequest(method, full_uri, buffer)
 
-    /* Default of application/json, but allow headers array to overwrite later */
-    if err == nil {
-      req.Header.Set("Content-Type", "application/json")
-    }
-  }
+		/* Default of application/json, but allow headers array to overwrite later */
+		if err == nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+	}
 
-  if err != nil {
-    log.Fatal(err)
-    return "", err
-  }
+	if err != nil {
+		log.Fatal(err)
+		return "", err
+	}
 
-  if client.debug {
-    log.Printf("api_client.go: Sending HTTP request to %s...\n", req.URL)
-  }
+	if client.debug {
+		log.Printf("api_client.go: Sending HTTP request to %s...\n", req.URL)
+	}
 
-  /* Allow for tokens or other pre-created secrets */
-  if len(client.headers) > 0 {
-    for n, v := range client.headers {
-      req.Header.Set(n, v)
-    }
-  }
+	/* Allow for tokens or other pre-created secrets */
+	if len(client.headers) > 0 {
+		for n, v := range client.headers {
+			req.Header.Set(n, v)
+		}
+	}
 
-  if client.username != "" && client.password != "" {
-    /* ... and fall back to basic auth if configured */
-    req.SetBasicAuth(client.username, client.password)
-  }
+	if client.username != "" && client.password != "" {
+		/* ... and fall back to basic auth if configured */
+		req.SetBasicAuth(client.username, client.password)
+	}
 
-  if client.debug {
-    log.Printf("api_client.go: Request headers:\n")
-    for name, headers := range req.Header {
-      for _, h := range headers {
-       log.Printf("api_client.go:   %v: %v", name, h)
-      }
-    }
+	if client.debug {
+		log.Printf("api_client.go: Request headers:\n")
+		for name, headers := range req.Header {
+			for _, h := range headers {
+				log.Printf("api_client.go:   %v: %v", name, h)
+			}
+		}
 
-    log.Printf("api_client.go: BODY:\n")
-    body := "<none>"
-    if req.Body != nil {
-      body = string(data)
-    }
-    log.Printf("%s\n", body)
-  }
+		log.Printf("api_client.go: BODY:\n")
+		body := "<none>"
+		if req.Body != nil {
+			body = string(data)
+		}
+		log.Printf("%s\n", body)
+	}
 
-  for num_redirects := client.redirects; num_redirects >= 0; num_redirects-- {
-    resp, err := client.http_client.Do(req)
+	for num_redirects := client.redirects; num_redirects >= 0; num_redirects-- {
+		resp, err := client.http_client.Do(req)
 
-    if err != nil {
-      //log.Printf("api_client.go: Error detected: %s\n", err)
-      return "", err
-    }
+		if err != nil {
+			//log.Printf("api_client.go: Error detected: %s\n", err)
+			return "", err
+		}
 
-    if client.debug {
-      log.Printf("api_client.go: Response code: %d\n", resp.StatusCode)
-      log.Printf("api_client.go: Response headers:\n")
-      for name, headers := range resp.Header {
-        for _, h := range headers {
-         log.Printf("api_client.go:   %v: %v", name, h)
-        }
-      }
-    }
+		if client.debug {
+			log.Printf("api_client.go: Response code: %d\n", resp.StatusCode)
+			log.Printf("api_client.go: Response headers:\n")
+			for name, headers := range resp.Header {
+				for _, h := range headers {
+					log.Printf("api_client.go:   %v: %v", name, h)
+				}
+			}
+		}
 
-    bodyBytes, err2 := ioutil.ReadAll(resp.Body)
-    resp.Body.Close()
+		bodyBytes, err2 := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
 
-    if err2 != nil { return "", err2 }
-    body := strings.TrimPrefix(string(bodyBytes), client.xssi_prefix)
+		if err2 != nil {
+			return "", err2
+		}
+		body := strings.TrimPrefix(string(bodyBytes), client.xssi_prefix)
 
-    if resp.StatusCode == 301 || resp.StatusCode == 302 {
-      //Redirecting... decrement num_redirects and proceed to the next loop
-      //uri = URI.parse(rsp['Location'])
-    } else if resp.StatusCode == 404 || resp.StatusCode < 200 || resp.StatusCode >= 303 {
-      return "", errors.New(fmt.Sprintf("Unexpected response code '%d': %s", resp.StatusCode, body))
-    } else {
-      if client.debug { log.Printf("api_client.go: BODY:\n%s\n", body) }
-      return body, nil
-    }
+		if resp.StatusCode == 301 || resp.StatusCode == 302 {
+			//Redirecting... decrement num_redirects and proceed to the next loop
+			//uri = URI.parse(rsp['Location'])
+		} else if resp.StatusCode == 404 || resp.StatusCode < 200 || resp.StatusCode >= 303 {
+			return "", errors.New(fmt.Sprintf("Unexpected response code '%d': %s", resp.StatusCode, body))
+		} else {
+			if client.debug {
+				log.Printf("api_client.go: BODY:\n%s\n", body)
+			}
+			return body, nil
+		}
 
-  } //End loop through redirect attempts
+	} //End loop through redirect attempts
 
-  return "", errors.New("Error - too many redirects!")
+	return "", errors.New("Error - too many redirects!")
 }

--- a/restapi/api_client_test.go
+++ b/restapi/api_client_test.go
@@ -18,7 +18,20 @@ func TestAPIClient(t *testing.T) {
 	setup_api_client_server()
 
 	/* Notice the intentional trailing / */
-	client, err := NewAPIClient("http://127.0.0.1:8080/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
+	opt := &apiClientOpt{
+		uri:                   "http://127.0.0.1:8080/",
+		insecure:              false,
+		username:              "",
+		password:              "",
+		headers:               make(map[string]string, 0),
+		timeout:               2,
+		id_attribute:          "id",
+		copy_keys:             make([]string, 0),
+		write_returns_object:  false,
+		create_returns_object: false,
+		debug:                 debug,
+	}
+	client, err := NewAPIClient(opt)
 
 	var res string
 

--- a/restapi/api_client_test.go
+++ b/restapi/api_client_test.go
@@ -1,72 +1,89 @@
 package restapi
 
 import (
-  "log"
-  "testing"
-  "net/http"
-  "time"
+	"log"
+	"net/http"
+	"testing"
+	"time"
 )
 
 var api_client_server *http.Server
 
 func TestAPIClient(t *testing.T) {
-  debug := false
+	debug := false
 
-  if debug { log.Println("client_test.go: Starting HTTP server") }
-  setup_api_client_server()
+	if debug {
+		log.Println("client_test.go: Starting HTTP server")
+	}
+	setup_api_client_server()
 
-  /* Notice the intentional trailing / */
-  client, err := NewAPIClient ("http://127.0.0.1:8080/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
+	/* Notice the intentional trailing / */
+	client, err := NewAPIClient("http://127.0.0.1:8080/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
 
-  var res string
+	var res string
 
-  if(debug) { log.Printf("api_client_test.go: Testing standard OK request\n") }
-  res, err = client.send_request("GET", "/ok", "")
-  if err != nil { t.Fatalf("client_test.go: %s", err) }
-  if res != "It works!" {
-    t.Fatalf("client_test.go: Got back '%s' but expected 'It works!'\n", res)
-  }
+	if debug {
+		log.Printf("api_client_test.go: Testing standard OK request\n")
+	}
+	res, err = client.send_request("GET", "/ok", "")
+	if err != nil {
+		t.Fatalf("client_test.go: %s", err)
+	}
+	if res != "It works!" {
+		t.Fatalf("client_test.go: Got back '%s' but expected 'It works!'\n", res)
+	}
 
-  if(debug) { log.Printf("api_client_test.go: Testing redirect request\n") }
-  res, err = client.send_request("GET", "/redirect", "")
-  if err != nil { t.Fatalf("client_test.go: %s", err) }
-  if res != "It works!" {
-    t.Fatalf("client_test.go: Got back '%s' but expected 'It works!'\n", res)
-  }
+	if debug {
+		log.Printf("api_client_test.go: Testing redirect request\n")
+	}
+	res, err = client.send_request("GET", "/redirect", "")
+	if err != nil {
+		t.Fatalf("client_test.go: %s", err)
+	}
+	if res != "It works!" {
+		t.Fatalf("client_test.go: Got back '%s' but expected 'It works!'\n", res)
+	}
 
-  /* Verify timeout works */
-  if(debug) { log.Printf("api_client_test.go: Testing timeout aborts requests\n") }
-  res, err = client.send_request("GET", "/slow", "")
-  if err == nil { t.Fatalf("client_test.go: Timeout did not trigger on slow request") }
+	/* Verify timeout works */
+	if debug {
+		log.Printf("api_client_test.go: Testing timeout aborts requests\n")
+	}
+	res, err = client.send_request("GET", "/slow", "")
+	if err == nil {
+		t.Fatalf("client_test.go: Timeout did not trigger on slow request")
+	}
 
-  if debug { log.Println("client_test.go: Stopping HTTP server") }
-  shutdown_api_client_server()
-  if debug { log.Println("client_test.go: Done") }
+	if debug {
+		log.Println("client_test.go: Stopping HTTP server")
+	}
+	shutdown_api_client_server()
+	if debug {
+		log.Println("client_test.go: Done")
+	}
 }
 
-func setup_api_client_server () {
-  serverMux := http.NewServeMux()
-  serverMux.HandleFunc("/ok", func(w http.ResponseWriter, r *http.Request) {
-    w.Write([]byte("It works!"))
-  })
-  serverMux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
-    time.Sleep(9999 * time.Second)
-    w.Write([]byte("This will never return!!!!!"))
-  })
-  serverMux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
-    http.Redirect(w, r, "/ok", http.StatusPermanentRedirect)
-  })
+func setup_api_client_server() {
+	serverMux := http.NewServeMux()
+	serverMux.HandleFunc("/ok", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("It works!"))
+	})
+	serverMux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(9999 * time.Second)
+		w.Write([]byte("This will never return!!!!!"))
+	})
+	serverMux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/ok", http.StatusPermanentRedirect)
+	})
 
-
-  api_client_server = &http.Server{
-    Addr: "127.0.0.1:8080",
-    Handler: serverMux,
-  }
-  go api_client_server.ListenAndServe()
-  /* let the server start */
-  time.Sleep(1 * time.Second)
+	api_client_server = &http.Server{
+		Addr:    "127.0.0.1:8080",
+		Handler: serverMux,
+	}
+	go api_client_server.ListenAndServe()
+	/* let the server start */
+	time.Sleep(1 * time.Second)
 }
 
-func shutdown_api_client_server () {
-  api_client_server.Close()
+func shutdown_api_client_server() {
+	api_client_server.Close()
 }

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -1,224 +1,258 @@
 package restapi
 
 import (
-  "log"
-  "errors"
-  "fmt"
-  "encoding/json"
-  "bytes"
-  "github.com/davecgh/go-spew/spew"
-  "strings"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/davecgh/go-spew/spew"
+	"log"
+	"strings"
 )
 
 type api_object struct {
-  api_client           *api_client
-  get_path             string
-  post_path            string
-  put_path             string
-  delete_path          string
-  debug                bool
-  id                   string
-  id_attribute         string
+	api_client   *api_client
+	get_path     string
+	post_path    string
+	put_path     string
+	delete_path  string
+	debug        bool
+	id           string
+	id_attribute string
 
-  /* Set internally */
-  data         map[string]interface{} /* Data as managed by the user */
-  api_data     map[string]interface{} /* Data as available from the API */
+	/* Set internally */
+	data     map[string]interface{} /* Data as managed by the user */
+	api_data map[string]interface{} /* Data as available from the API */
 }
 
 // Make an api_object to manage a RESTful object in an API
-func NewAPIObject (i_client *api_client, i_get_path string, i_post_path string, i_put_path string, i_delete_path string, i_id string, i_ida string, i_data string, i_debug bool) (*api_object, error) {
-  if i_debug {
-    log.Printf("api_object.go: Constructing debug api_object\n")
-    log.Printf(" id: %s\n", i_id)
-  }
+func NewAPIObject(i_client *api_client, i_get_path string, i_post_path string, i_put_path string, i_delete_path string, i_id string, i_ida string, i_data string, i_debug bool) (*api_object, error) {
+	if i_debug {
+		log.Printf("api_object.go: Constructing debug api_object\n")
+		log.Printf(" id: %s\n", i_id)
+	}
 
-  /* id_attribute can be set either on the client (to apply for all calls with the server)
-     or on a per object basis (for only calls to this kind of object).
-     Permit overridding from the API client here by using the client-wide value only
-     if a per-object value is not set */
-  id_attr := i_ida
-  if i_ida == "" {
-    id_attr = i_client.id_attribute
-  }
+	/* id_attribute can be set either on the client (to apply for all calls with the server)
+	   or on a per object basis (for only calls to this kind of object).
+	   Permit overridding from the API client here by using the client-wide value only
+	   if a per-object value is not set */
+	id_attr := i_ida
+	if i_ida == "" {
+		id_attr = i_client.id_attribute
+	}
 
-  obj := api_object{
-    api_client: i_client,
-    get_path: i_get_path,
-    post_path: i_post_path,
-    put_path: i_put_path,
-    delete_path: i_delete_path,
-    debug: i_debug,
-    id: i_id,
-    id_attribute: id_attr,
-    data: make(map[string]interface{}),
-    api_data: make(map[string]interface{}),
-  }
+	obj := api_object{
+		api_client:   i_client,
+		get_path:     i_get_path,
+		post_path:    i_post_path,
+		put_path:     i_put_path,
+		delete_path:  i_delete_path,
+		debug:        i_debug,
+		id:           i_id,
+		id_attribute: id_attr,
+		data:         make(map[string]interface{}),
+		api_data:     make(map[string]interface{}),
+	}
 
-  if "" == i_get_path    { return nil, errors.New("No GET path passed to api_object constructor") }
-  if "" == i_post_path   { return nil, errors.New("No POST path passed to api_object constructor") }
-  if "" == i_put_path    { return nil, errors.New("No PUT path passed to api_object constructor") }
-  if "" == i_delete_path { return nil, errors.New("No DELETE path passed to api_object constructor") }
-  if "" == i_data        { return nil, errors.New("No data passed to api_object constructor") }
+	if "" == i_get_path {
+		return nil, errors.New("No GET path passed to api_object constructor")
+	}
+	if "" == i_post_path {
+		return nil, errors.New("No POST path passed to api_object constructor")
+	}
+	if "" == i_put_path {
+		return nil, errors.New("No PUT path passed to api_object constructor")
+	}
+	if "" == i_delete_path {
+		return nil, errors.New("No DELETE path passed to api_object constructor")
+	}
+	if "" == i_data {
+		return nil, errors.New("No data passed to api_object constructor")
+	}
 
-  if i_data != ""{
-    if i_debug { log.Printf("api_object.go: Parsing data: '%s'", i_data) }
+	if i_data != "" {
+		if i_debug {
+			log.Printf("api_object.go: Parsing data: '%s'", i_data)
+		}
 
-    err := json.Unmarshal([]byte(i_data), &obj.data)
-    if err != nil {
-      return nil, err
-    }
+		err := json.Unmarshal([]byte(i_data), &obj.data)
+		if err != nil {
+			return nil, err
+		}
 
-    /* Opportunistically set the object's ID if it is provided in the data.
-       If it is not set, we will get it later in synchronize_state */
-    if obj.id == "" {
-      var tmp string
-      tmp, err = GetStringAtKey(obj.data, obj.id_attribute, obj.debug)
-      if err == nil {
-        if i_debug { log.Printf("api_object.go: opportunisticly set id from data provided.") }
-        obj.id = tmp
-      } else if !obj.api_client.write_returns_object && !obj.api_client.create_returns_object {
-        /* If the id is not set and we cannot obtain it
-	   later, error out to be safe */
-        return nil, errors.New(fmt.Sprintf("Provided data does not have %s attribute for the object's id and the client is not configured to read the object from a POST response. Without an id, the object cannot be managed.", obj.id_attribute))
-      }
-    }
-  }
+		/* Opportunistically set the object's ID if it is provided in the data.
+		   If it is not set, we will get it later in synchronize_state */
+		if obj.id == "" {
+			var tmp string
+			tmp, err = GetStringAtKey(obj.data, obj.id_attribute, obj.debug)
+			if err == nil {
+				if i_debug {
+					log.Printf("api_object.go: opportunisticly set id from data provided.")
+				}
+				obj.id = tmp
+			} else if !obj.api_client.write_returns_object && !obj.api_client.create_returns_object {
+				/* If the id is not set and we cannot obtain it
+				   later, error out to be safe */
+				return nil, errors.New(fmt.Sprintf("Provided data does not have %s attribute for the object's id and the client is not configured to read the object from a POST response. Without an id, the object cannot be managed.", obj.id_attribute))
+			}
+		}
+	}
 
-  if obj.debug { log.Printf("api_object.go: Constructed object: %s", obj.toString()) }
-  return &obj, nil
+	if obj.debug {
+		log.Printf("api_object.go: Constructed object: %s", obj.toString())
+	}
+	return &obj, nil
 }
 
 // Convert the important bits about this object to string representation
 // This is useful for debugging.
 func (obj *api_object) toString() string {
-  var buffer bytes.Buffer
-  buffer.WriteString(fmt.Sprintf("id: %s\n", obj.id))
-  buffer.WriteString(fmt.Sprintf("get_path: %s\n", obj.get_path))
-  buffer.WriteString(fmt.Sprintf("post_path: %s\n", obj.post_path))
-  buffer.WriteString(fmt.Sprintf("put_path: %s\n", obj.put_path))
-  buffer.WriteString(fmt.Sprintf("delete_path: %s\n", obj.delete_path))
-  buffer.WriteString(fmt.Sprintf("debug: %t\n", obj.debug))
-  buffer.WriteString(fmt.Sprintf("data: %s\n", spew.Sdump(obj.data)))
-  buffer.WriteString(fmt.Sprintf("api_data: %s\n", spew.Sdump(obj.api_data)))
-  return buffer.String()
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("id: %s\n", obj.id))
+	buffer.WriteString(fmt.Sprintf("get_path: %s\n", obj.get_path))
+	buffer.WriteString(fmt.Sprintf("post_path: %s\n", obj.post_path))
+	buffer.WriteString(fmt.Sprintf("put_path: %s\n", obj.put_path))
+	buffer.WriteString(fmt.Sprintf("delete_path: %s\n", obj.delete_path))
+	buffer.WriteString(fmt.Sprintf("debug: %t\n", obj.debug))
+	buffer.WriteString(fmt.Sprintf("data: %s\n", spew.Sdump(obj.data)))
+	buffer.WriteString(fmt.Sprintf("api_data: %s\n", spew.Sdump(obj.api_data)))
+	return buffer.String()
 }
 
 /* Centralized function to ensure that our data as managed by
    the api_object is updated with data that has come back from
    the API */
 func (obj *api_object) update_state(state string) error {
-  if obj.debug { log.Printf("api_object.go: Updating API object state to '%s'\n", state) }
+	if obj.debug {
+		log.Printf("api_object.go: Updating API object state to '%s'\n", state)
+	}
 
-  /* Other option - Decode as JSON Numbers instead of golang datatypes
-  d := json.NewDecoder(strings.NewReader(res_str))
-  d.UseNumber()
-  err = d.Decode(&obj.api_data)
-  */
-  err := json.Unmarshal([]byte(state), &obj.api_data)
-  if err != nil { return err }
+	/* Other option - Decode as JSON Numbers instead of golang datatypes
+	d := json.NewDecoder(strings.NewReader(res_str))
+	d.UseNumber()
+	err = d.Decode(&obj.api_data)
+	*/
+	err := json.Unmarshal([]byte(state), &obj.api_data)
+	if err != nil {
+		return err
+	}
 
-  /* A usable ID was not passed (in constructor or here), 
-     so we have to guess what it is from the data structure */
-  if obj.id == "" {
-    val, err := GetStringAtKey(obj.api_data, obj.id_attribute, obj.debug)
-    if err != nil {
-      return fmt.Errorf("api_object.go: Error extracting ID from data element: %s", err)
-    }
-    obj.id = val
-  } else if obj.debug {
-    log.Printf("api_object.go: Not updating id. It is already set to '%s'\n", obj.id)
-  }
+	/* A usable ID was not passed (in constructor or here),
+	   so we have to guess what it is from the data structure */
+	if obj.id == "" {
+		val, err := GetStringAtKey(obj.api_data, obj.id_attribute, obj.debug)
+		if err != nil {
+			return fmt.Errorf("api_object.go: Error extracting ID from data element: %s", err)
+		}
+		obj.id = val
+	} else if obj.debug {
+		log.Printf("api_object.go: Not updating id. It is already set to '%s'\n", obj.id)
+	}
 
-  /* Any keys that come from the data we want to copy are done here */
-  if len(obj.api_client.copy_keys) > 0 {
-    for _, key := range obj.api_client.copy_keys {
-      if obj.debug {
-        log.Printf("api_object.go: Copying key '%s' from api_data (%v) to data (%v)\n", key, obj.api_data[key], obj.data[key])
-      }
-      obj.data[key] = obj.api_data[key]
-    }
-  } else if obj.debug {
-    log.Printf("api_object.go: copy_keys is empty - not attempting to copy data")
-  }
+	/* Any keys that come from the data we want to copy are done here */
+	if len(obj.api_client.copy_keys) > 0 {
+		for _, key := range obj.api_client.copy_keys {
+			if obj.debug {
+				log.Printf("api_object.go: Copying key '%s' from api_data (%v) to data (%v)\n", key, obj.api_data[key], obj.data[key])
+			}
+			obj.data[key] = obj.api_data[key]
+		}
+	} else if obj.debug {
+		log.Printf("api_object.go: copy_keys is empty - not attempting to copy data")
+	}
 
-  if obj.debug {
-    log.Printf("api_object.go: final object after synchronization of state:\n%+v\n", obj.toString())
-  }
-  return err
+	if obj.debug {
+		log.Printf("api_object.go: final object after synchronization of state:\n%+v\n", obj.toString())
+	}
+	return err
 }
 
 func (obj *api_object) create_object() error {
-  /* Failsafe: The constructor should prevent this situation, but
-     protect here also. If no id is set, and the API does not respond
-     with the id of whatever gets created, we have no way to know what
-     the object's id will be. Abandon this attempt */
-  if obj.id == "" && !obj.api_client.write_returns_object && !obj.api_client.create_returns_object {
-    return errors.New("ERROR: Provided object does not have an id set and the client is not configured to read the object from a POST or PUT response. Without an id, the object cannot be managed.")
-  }
+	/* Failsafe: The constructor should prevent this situation, but
+	   protect here also. If no id is set, and the API does not respond
+	   with the id of whatever gets created, we have no way to know what
+	   the object's id will be. Abandon this attempt */
+	if obj.id == "" && !obj.api_client.write_returns_object && !obj.api_client.create_returns_object {
+		return errors.New("ERROR: Provided object does not have an id set and the client is not configured to read the object from a POST or PUT response. Without an id, the object cannot be managed.")
+	}
 
-  b, _ := json.Marshal(obj.data)
-  res_str, err := obj.api_client.send_request("POST", strings.Replace(obj.post_path, "{id}", obj.id, -1), string(b))
-  if err != nil { return err }
+	b, _ := json.Marshal(obj.data)
+	res_str, err := obj.api_client.send_request("POST", strings.Replace(obj.post_path, "{id}", obj.id, -1), string(b))
+	if err != nil {
+		return err
+	}
 
-  /* We will need to sync state as well as get the object's ID */
-  if obj.api_client.write_returns_object || obj.api_client.create_returns_object {
-    if obj.debug {
-      log.Printf("api_object.go: Parsing response from POST to update internal structures (write_returns_object=%t, create_returns_object=%t)...\n",
-        obj.api_client.write_returns_object, obj.api_client.create_returns_object)
-    }
-    err = obj.update_state(res_str)
-    /* Yet another failsafe. In case something terrible went wrong internally,
-       bail out so the user at least knows that the ID did not get set. */
-    if obj.id == "" { return errors.New("Internal validation failed. Object ID is not set, but *may* have been created. This should never happen!") }
-  } else {
-    if obj.debug {
-      log.Printf("api_object.go: Requesting created object from API (write_returns_object=%t, create_returns_object=%t)...\n",
-        obj.api_client.write_returns_object, obj.api_client.create_returns_object)
-    }
-    err = obj.read_object()
-  }
-  return err
+	/* We will need to sync state as well as get the object's ID */
+	if obj.api_client.write_returns_object || obj.api_client.create_returns_object {
+		if obj.debug {
+			log.Printf("api_object.go: Parsing response from POST to update internal structures (write_returns_object=%t, create_returns_object=%t)...\n",
+				obj.api_client.write_returns_object, obj.api_client.create_returns_object)
+		}
+		err = obj.update_state(res_str)
+		/* Yet another failsafe. In case something terrible went wrong internally,
+		   bail out so the user at least knows that the ID did not get set. */
+		if obj.id == "" {
+			return errors.New("Internal validation failed. Object ID is not set, but *may* have been created. This should never happen!")
+		}
+	} else {
+		if obj.debug {
+			log.Printf("api_object.go: Requesting created object from API (write_returns_object=%t, create_returns_object=%t)...\n",
+				obj.api_client.write_returns_object, obj.api_client.create_returns_object)
+		}
+		err = obj.read_object()
+	}
+	return err
 }
 
 func (obj *api_object) read_object() error {
-  if obj.id == "" {
-    return errors.New("Cannot read an object unless the ID has been set.")
-  }
+	if obj.id == "" {
+		return errors.New("Cannot read an object unless the ID has been set.")
+	}
 
-  res_str, err := obj.api_client.send_request("GET", strings.Replace(obj.get_path, "{id}", obj.id, -1), "")
-  if err != nil { return err }
+	res_str, err := obj.api_client.send_request("GET", strings.Replace(obj.get_path, "{id}", obj.id, -1), "")
+	if err != nil {
+		return err
+	}
 
-  err = obj.update_state(res_str)
-  return err
+	err = obj.update_state(res_str)
+	return err
 }
 
 func (obj *api_object) update_object() error {
-  if obj.id == "" {
-    return errors.New("Cannot update an object unless the ID has been set.")
-  }
+	if obj.id == "" {
+		return errors.New("Cannot update an object unless the ID has been set.")
+	}
 
-  b, _ := json.Marshal(obj.data)
-  res_str, err := obj.api_client.send_request("PUT", strings.Replace(obj.put_path, "{id}", obj.id, -1), string(b))
-  if err != nil { return err }
+	b, _ := json.Marshal(obj.data)
+	res_str, err := obj.api_client.send_request("PUT", strings.Replace(obj.put_path, "{id}", obj.id, -1), string(b))
+	if err != nil {
+		return err
+	}
 
-  if obj.api_client.write_returns_object {
-    if obj.debug { log.Printf("api_object.go: Parsing response from PUT to update internal structures (write_returns_object=true)...\n") }
-    err = obj.update_state(res_str)
-  } else {
-    if obj.debug { log.Printf("api_object.go: Requesting updated object from API (write_returns_object=false)...\n") }
-    err = obj.read_object()
-  }
-  return err
+	if obj.api_client.write_returns_object {
+		if obj.debug {
+			log.Printf("api_object.go: Parsing response from PUT to update internal structures (write_returns_object=true)...\n")
+		}
+		err = obj.update_state(res_str)
+	} else {
+		if obj.debug {
+			log.Printf("api_object.go: Requesting updated object from API (write_returns_object=false)...\n")
+		}
+		err = obj.read_object()
+	}
+	return err
 }
 
 func (obj *api_object) delete_object() error {
-  if obj.id == "" {
-    log.Printf("WARNING: Attempting to delete an object that has no id set. Assuming this is OK.\n")
-    return nil
-  }
+	if obj.id == "" {
+		log.Printf("WARNING: Attempting to delete an object that has no id set. Assuming this is OK.\n")
+		return nil
+	}
 
-  _, err := obj.api_client.send_request("DELETE", strings.Replace(obj.delete_path, "{id}", obj.id, -1), "")
-  if err != nil { return err }
+	_, err := obj.api_client.send_request("DELETE", strings.Replace(obj.delete_path, "{id}", obj.id, -1), "")
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }

--- a/restapi/api_object_test.go
+++ b/restapi/api_object_test.go
@@ -1,11 +1,11 @@
 package restapi
 
 import (
-  "log"
-  "testing"
-  "encoding/json"
-  "fmt"
-  "github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"encoding/json"
+	"fmt"
+	"github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"log"
+	"testing"
 )
 
 var test_debug = false
@@ -14,134 +14,156 @@ var api_object_debug = false
 var api_client_debug = false
 
 type test_api_object struct {
-  Test_case string             `json:"Test_case"`
-  Id        string             `json:"Id"`
-  Revision  int                `json:"Revision,omitempty"`
-  Thing     string             `json:"Thing,omitempty"`
-  Is_cat    bool               `json:"Is_cat,omitempty"`
-  Colors    []string           `json:"Colors,omitempty"`
-  Attrs     map[string]string  `json:"Attrs,omitempty"`
+	Test_case string            `json:"Test_case"`
+	Id        string            `json:"Id"`
+	Revision  int               `json:"Revision,omitempty"`
+	Thing     string            `json:"Thing,omitempty"`
+	Is_cat    bool              `json:"Is_cat,omitempty"`
+	Colors    []string          `json:"Colors,omitempty"`
+	Attrs     map[string]string `json:"Attrs,omitempty"`
 }
 
 func TestAPIObject(t *testing.T) {
-  if test_debug { log.Println("api_object_test.go: Creating test API objects") }
+	if test_debug {
+		log.Println("api_object_test.go: Creating test API objects")
+	}
 
-  /* Holds the full list of api_object items that we are testing
-     indexed by the name of the test case */
-  testing_objects := make(map[string]*api_object)
+	/* Holds the full list of api_object items that we are testing
+	   indexed by the name of the test case */
+	testing_objects := make(map[string]*api_object)
 
-  /* Messy... fakeserver wants "generic" objects, but it is much easier
-     to write our test cases with typed (test_api_object) objects. Make
-     maps of both */
-  generated_objects := make(map[string]test_api_object)
-  api_server_objects := make(map[string]map[string]interface{})
-  GenerateTestObjects(&generated_objects, &api_server_objects, t, test_debug)
+	/* Messy... fakeserver wants "generic" objects, but it is much easier
+	   to write our test cases with typed (test_api_object) objects. Make
+	   maps of both */
+	generated_objects := make(map[string]test_api_object)
+	api_server_objects := make(map[string]map[string]interface{})
+	GenerateTestObjects(&generated_objects, &api_server_objects, t, test_debug)
 
-  client, err := NewAPIClient (
-    "http://127.0.0.1:8081/",  /* URL */
-    false,                     /* insecure */
-    "",                        /* username */
-    "",                        /* password */
-    make(map[string]string, 0),/* additional headers to send */
-    5,                         /* HTTP Timeout in seconds */
-    "Id",                      /* Attribute from server that serves as ID */
-    []string{ "Thing" },       /* keys to copy from api_data to data */
-    true,                      /* Write returns object */
-    false,                     /* Create returns object */
-    api_client_debug,          /* Debug logging */
-    )
+	client, err := NewAPIClient(
+		"http://127.0.0.1:8081/",   /* URL */
+		false,                      /* insecure */
+		"",                         /* username */
+		"",                         /* password */
+		make(map[string]string, 0), /* additional headers to send */
+		5,                          /* HTTP Timeout in seconds */
+		"Id",                       /* Attribute from server that serves as ID */
+		[]string{"Thing"},          /* keys to copy from api_data to data */
+		true,                       /* Write returns object */
+		false,                      /* Create returns object */
+		api_client_debug,           /* Debug logging */
+	)
 
+	/* Construct a local map of test case objects with only the ID populated */
+	if test_debug {
+		log.Println("api_object_test.go: Building test objects...")
+	}
+	for id, test_obj := range generated_objects {
+		if test_debug {
+			log.Printf("api_object_test.go:   '%s'\n", id)
+		}
+		o, err := NewAPIObject(
+			client,                            /* The HTTP client created above */
+			"/api/objects/{id}",               /* path to the "object" in the test server for GET (note: id will automatically be appended) */
+			"/api/objects",                    /* path to the "object" in the test server for POST (note: id will automatically be appended) */
+			"/api/objects/{id}",               /* path to the "object" in the test server for PUT (note: id will automatically be appended) */
+			"/api/objects/{id}",               /* path to the "object" in the test server for DELETE (note: id will automatically be appended) */
+			"",                                /* Do not set an ID to force the constructor to verify id_attribute works */
+			"",                                /* Use the client's value for id_attribute */
+			fmt.Sprintf(`{ "Id": "%s" }`, id), /* Start with only an empty JSON object ID as our "data" */
+			api_object_debug,                  /* Whether the object's debug is enabled */
+		)
+		if err != nil {
+			t.Fatalf("api_object_test.go: Failed to create new api_object for id '%s'", id)
+		} else {
+			test_case := test_obj.Test_case
+			testing_objects[test_case] = o
+		}
+	}
 
-  /* Construct a local map of test case objects with only the ID populated */
-  if test_debug { log.Println("api_object_test.go: Building test objects...") }
-  for id, test_obj := range generated_objects {
-    if test_debug { log.Printf("api_object_test.go:   '%s'\n", id) }
-    o, err := NewAPIObject(
-      client,                            /* The HTTP client created above */
-      "/api/objects/{id}",               /* path to the "object" in the test server for GET (note: id will automatically be appended) */
-      "/api/objects",                    /* path to the "object" in the test server for POST (note: id will automatically be appended) */
-      "/api/objects/{id}",               /* path to the "object" in the test server for PUT (note: id will automatically be appended) */
-      "/api/objects/{id}",               /* path to the "object" in the test server for DELETE (note: id will automatically be appended) */
-      "",                                /* Do not set an ID to force the constructor to verify id_attribute works */
-      "",                                /* Use the client's value for id_attribute */
-      fmt.Sprintf(`{ "Id": "%s" }`, id), /* Start with only an empty JSON object ID as our "data" */
-      api_object_debug,                  /* Whether the object's debug is enabled */
-    )
-    if err != nil {
-      t.Fatalf("api_object_test.go: Failed to create new api_object for id '%s'", id)
-    } else {
-      test_case := test_obj.Test_case
-      testing_objects[test_case] = o
-    }
-  }
+	if test_debug {
+		log.Println("api_object_test.go: Starting HTTP server")
+	}
+	svr := fakeserver.NewFakeServer(8081, api_server_objects, true, http_server_debug, "")
 
-  if test_debug { log.Println("api_object_test.go: Starting HTTP server") }
-  svr := fakeserver.NewFakeServer(8081, api_server_objects, true, http_server_debug, "")
+	/* Loop through all of the objects and GET their data from the server */
+	if test_debug {
+		log.Printf("api_object_test.go: Testing read_object()")
+	}
+	for Test_case, _ := range testing_objects {
+		if test_debug {
+			log.Printf("api_object_test.go: Getting data for '%s' test case from server\n", Test_case)
+		}
+		err := testing_objects[Test_case].read_object()
+		if err != nil {
+			t.Fatalf("api_object_test.go: Failed to read data for test case '%s': %s", Test_case, err)
+		}
+	}
 
-  /* Loop through all of the objects and GET their data from the server */
-  if test_debug { log.Printf("api_object_test.go: Testing read_object()") }
-  for Test_case, _ := range testing_objects {
-    if test_debug { log.Printf("api_object_test.go: Getting data for '%s' test case from server\n", Test_case) }
-    err := testing_objects[Test_case].read_object()
-    if err != nil {
-      t.Fatalf("api_object_test.go: Failed to read data for test case '%s': %s", Test_case, err)
-    }
-  }
+	/* Verify our copy_keys is happy by seeing if Thing made it into the data hash */
+	if test_debug {
+		log.Printf("api_object_test.go: Testing copy_keys()")
+	}
+	if testing_objects["normal"].data["Thing"].(string) == "" {
+		t.Fatalf("api_object_test.go: copy_keys for 'normal' object failed. Expected 'Thing' to be non-empty, but got '%+v'\n", testing_objects["normal"].data["Thing"])
+	}
 
-  /* Verify our copy_keys is happy by seeing if Thing made it into the data hash */
-  if test_debug { log.Printf("api_object_test.go: Testing copy_keys()") }
-  if testing_objects["normal"].data["Thing"].(string) == "" {
-    t.Fatalf("api_object_test.go: copy_keys for 'normal' object failed. Expected 'Thing' to be non-empty, but got '%+v'\n", testing_objects["normal"].data["Thing"])
-  }
+	/* Go ahead and update one of our objects */
+	if test_debug {
+		log.Printf("api_object_test.go: Testing update_object()")
+	}
+	testing_objects["minimal"].data["Thing"] = "spoon"
+	testing_objects["minimal"].update_object()
+	if err != nil {
+		t.Fatalf("api_object_test.go: Failed in update_object() test: %s", err)
+	} else if testing_objects["minimal"].api_data["Thing"] != "spoon" {
+		t.Fatalf("api_object_test.go: Failed to update 'Thing' field of 'minimal' object. Expected it to be '%s' but it is '%s'\nFull obj: %+v\n",
+			"spoon", testing_objects["minimal"].api_data["Thing"], testing_objects["minimal"])
+	}
 
-  /* Go ahead and update one of our objects */
-  if test_debug { log.Printf("api_object_test.go: Testing update_object()") }
-  testing_objects["minimal"].data["Thing"] = "spoon"
-  testing_objects["minimal"].update_object()
-  if err != nil {
-    t.Fatalf("api_object_test.go: Failed in update_object() test: %s", err)
-  } else if testing_objects["minimal"].api_data["Thing"] != "spoon" {
-    t.Fatalf("api_object_test.go: Failed to update 'Thing' field of 'minimal' object. Expected it to be '%s' but it is '%s'\nFull obj: %+v\n",
-      "spoon", testing_objects["minimal"].api_data["Thing"], testing_objects["minimal"])
-  }
+	/* Delete one and make sure a 404 follows */
+	if test_debug {
+		log.Printf("api_object_test.go: Testing delete_object()")
+	}
+	testing_objects["pet"].delete_object()
+	err = testing_objects["pet"].read_object()
+	if err == nil {
+		t.Fatalf("api_object_test.go: 'pet' object deleted, but 404 not returned when getting it.\n")
+	}
 
-  /* Delete one and make sure a 404 follows */
-  if test_debug { log.Printf("api_object_test.go: Testing delete_object()") }
-  testing_objects["pet"].delete_object()
-  err = testing_objects["pet"].read_object()
-  if err == nil {
-    t.Fatalf("api_object_test.go: 'pet' object deleted, but 404 not returned when getting it.\n")
-  }
+	/* Recreate the one we just got rid of */
+	if test_debug {
+		log.Printf("api_object_test.go: Testing create_object()")
+	}
+	testing_objects["pet"].data["Thing"] = "dog"
+	err = testing_objects["pet"].create_object()
+	if err != nil {
+		t.Fatalf("api_object_test.go: Failed in create_object() test: %s", err)
+	} else if testing_objects["minimal"].api_data["Thing"] != "spoon" {
+		t.Fatalf("api_object_test.go: Failed to update 'Thing' field of 'minimal' object. Expected it to be '%s' but it is '%s'\nFull obj: %+v\n",
+			"spoon", testing_objects["minimal"].api_data["Thing"], testing_objects["minimal"])
+	}
 
-  /* Recreate the one we just got rid of */
-  if test_debug { log.Printf("api_object_test.go: Testing create_object()") }
-  testing_objects["pet"].data["Thing"] = "dog"
-  err = testing_objects["pet"].create_object()
-  if err != nil {
-    t.Fatalf("api_object_test.go: Failed in create_object() test: %s", err)
-  } else if testing_objects["minimal"].api_data["Thing"] != "spoon" {
-    t.Fatalf("api_object_test.go: Failed to update 'Thing' field of 'minimal' object. Expected it to be '%s' but it is '%s'\nFull obj: %+v\n",
-      "spoon", testing_objects["minimal"].api_data["Thing"], testing_objects["minimal"])
-  }
+	/* verify it's there */
+	err = testing_objects["pet"].read_object()
+	if err != nil {
+		t.Fatalf("api_object_test.go: Failed in read_object() test: %s", err)
+	} else if testing_objects["pet"].api_data["Thing"] != "dog" {
+		t.Fatalf("api_object_test.go: Failed in create_object() test. Object created is xpected it to be '%s' but it is '%s'\nFull obj: %+v\n",
+			"dog", testing_objects["minimal"].api_data["Thing"], testing_objects["minimal"])
+	}
 
-  /* verify it's there */
-  err = testing_objects["pet"].read_object()
-  if err != nil {
-    t.Fatalf("api_object_test.go: Failed in read_object() test: %s", err)
-  } else if testing_objects["pet"].api_data["Thing"] != "dog" {
-    t.Fatalf("api_object_test.go: Failed in create_object() test. Object created is xpected it to be '%s' but it is '%s'\nFull obj: %+v\n",
-      "dog", testing_objects["minimal"].api_data["Thing"], testing_objects["minimal"])
-  }
-
-  if test_debug { log.Println("api_object_test.go: Stopping HTTP server") }
-  svr.Shutdown()
-  if test_debug { log.Println("api_object_test.go: Done") }
+	if test_debug {
+		log.Println("api_object_test.go: Stopping HTTP server")
+	}
+	svr.Shutdown()
+	if test_debug {
+		log.Println("api_object_test.go: Done")
+	}
 }
 
-
-func GenerateTestObjects (typed *map[string]test_api_object, untyped *map[string]map[string]interface{}, t *testing.T, test_debug bool) {
-  add_test_api_object(
-    `{
+func GenerateTestObjects(typed *map[string]test_api_object, untyped *map[string]map[string]interface{}, t *testing.T, test_debug bool) {
+	add_test_api_object(
+		`{
       "Test_case": "normal",
       "Id": "1",
       "Revision": 1,
@@ -157,15 +179,15 @@ func GenerateTestObjects (typed *map[string]test_api_object, untyped *map[string
       }
     }`, typed, untyped, t, test_debug)
 
-  add_test_api_object(
-    `{
+	add_test_api_object(
+		`{
       "Test_case": "minimal",
       "Id": "2",
       "Thing": "fork"
     }`, typed, untyped, t, test_debug)
 
-  add_test_api_object(
-    `{
+	add_test_api_object(
+		`{
       "Test_case": "no Colors",
       "Id": "3",
       "Thing": "paper",
@@ -175,8 +197,8 @@ func GenerateTestObjects (typed *map[string]test_api_object, untyped *map[string
         "width": "11 in"
       }
     }`, typed, untyped, t, test_debug)
-  add_test_api_object(
-    `{
+	add_test_api_object(
+		`{
       "Test_case": "no Attrs",
       "Id": "4",
       "Thing": "nothing",
@@ -186,8 +208,8 @@ func GenerateTestObjects (typed *map[string]test_api_object, untyped *map[string
       ]
     }`, typed, untyped, t, test_debug)
 
-  add_test_api_object(
-    `{
+	add_test_api_object(
+		`{
       "Test_case": "pet",
       "Id": "5",
       "Thing": "cat",
@@ -203,28 +225,32 @@ func GenerateTestObjects (typed *map[string]test_api_object, untyped *map[string
     }`, typed, untyped, t, test_debug)
 }
 
-func add_test_api_object (input string, test_api_objects *map[string]test_api_object, api_server_objects *map[string]map[string]interface{}, t *testing.T, test_debug bool) {
-  var err error
-  var id string
-  var test_case string
-  var test_obj test_api_object
-  api_server_obj := make(map[string]interface{})
+func add_test_api_object(input string, test_api_objects *map[string]test_api_object, api_server_objects *map[string]map[string]interface{}, t *testing.T, test_debug bool) {
+	var err error
+	var id string
+	var test_case string
+	var test_obj test_api_object
+	api_server_obj := make(map[string]interface{})
 
-  err = json.Unmarshal([]byte(input), &test_obj)
-  if err != nil {
-    t.Fatalf("api_object_test.go: Failed to unmarshall JSON (to test_api_object) from '%s'", input)
-  } else {
-    id = test_obj.Id
-    test_case = test_obj.Test_case
-    if test_debug { log.Printf("api_object_test.go: Adding test object for case '%s' as id '%s'\n", test_case, id) }
-    (*test_api_objects)[id] = test_obj
-  }
+	err = json.Unmarshal([]byte(input), &test_obj)
+	if err != nil {
+		t.Fatalf("api_object_test.go: Failed to unmarshall JSON (to test_api_object) from '%s'", input)
+	} else {
+		id = test_obj.Id
+		test_case = test_obj.Test_case
+		if test_debug {
+			log.Printf("api_object_test.go: Adding test object for case '%s' as id '%s'\n", test_case, id)
+		}
+		(*test_api_objects)[id] = test_obj
+	}
 
-  err = json.Unmarshal([]byte(input), &api_server_obj)
-  if err != nil {
-    t.Fatalf("api_object_test.go: Failed to unmarshall JSON (to api_server_object) from '%s'", input)
-  } else {
-    if test_debug { log.Printf("api_object_test.go: Adding API server test object for case '%s' as id '%s'\n", test_case, id) }
-    (*api_server_objects)[id] = api_server_obj
-  }
+	err = json.Unmarshal([]byte(input), &api_server_obj)
+	if err != nil {
+		t.Fatalf("api_object_test.go: Failed to unmarshall JSON (to api_server_object) from '%s'", input)
+	} else {
+		if test_debug {
+			log.Printf("api_object_test.go: Adding API server test object for case '%s' as id '%s'\n", test_case, id)
+		}
+		(*api_server_objects)[id] = api_server_obj
+	}
 }

--- a/restapi/api_object_test.go
+++ b/restapi/api_object_test.go
@@ -39,19 +39,20 @@ func TestAPIObject(t *testing.T) {
 	api_server_objects := make(map[string]map[string]interface{})
 	GenerateTestObjects(&generated_objects, &api_server_objects, t, test_debug)
 
-	client, err := NewAPIClient(
-		"http://127.0.0.1:8081/",   /* URL */
-		false,                      /* insecure */
-		"",                         /* username */
-		"",                         /* password */
-		make(map[string]string, 0), /* additional headers to send */
-		5,                          /* HTTP Timeout in seconds */
-		"Id",                       /* Attribute from server that serves as ID */
-		[]string{"Thing"},          /* keys to copy from api_data to data */
-		true,                       /* Write returns object */
-		false,                      /* Create returns object */
-		api_client_debug,           /* Debug logging */
-	)
+	opt := &apiClientOpt{
+		uri:                   "http://127.0.0.1:8081/",
+		insecure:              false,
+		username:              "",
+		password:              "",
+		headers:               make(map[string]string, 0),
+		timeout:               5,
+		id_attribute:          "Id",
+		copy_keys:             []string{"Thing"},
+		write_returns_object:  true,
+		create_returns_object: false,
+		debug:                 api_client_debug,
+	}
+	client, err := NewAPIClient(opt)
 
 	/* Construct a local map of test case objects with only the ID populated */
 	if test_debug {

--- a/restapi/common.go
+++ b/restapi/common.go
@@ -1,10 +1,10 @@
 package restapi
 
 import (
-  "github.com/hashicorp/terraform/helper/schema"
-  "fmt"
-  "log"
-  "strings"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
 )
 
 /* Simple helper routine to build an api_object struct
@@ -13,150 +13,175 @@ import (
    results in a new object created */
 func make_api_object(d *schema.ResourceData, m interface{}) (*api_object, error) {
 
-  post_path := d.Get("path").(string)
-  get_path := d.Get("path").(string) + "/{id}"
-  put_path := d.Get("path").(string) + "/{id}"
-  delete_path := d.Get("path").(string) + "/{id}"
+	post_path := d.Get("path").(string)
+	get_path := d.Get("path").(string) + "/{id}"
+	put_path := d.Get("path").(string) + "/{id}"
+	delete_path := d.Get("path").(string) + "/{id}"
 
-  /* Allow user to override provider-level id_attribute */
-  id_attribute := m.(*api_client).id_attribute
-  if "" != d.Get("id_attribute").(string) {
-    id_attribute = d.Get("id_attribute").(string)
-  }
+	/* Allow user to override provider-level id_attribute */
+	id_attribute := m.(*api_client).id_attribute
+	if "" != d.Get("id_attribute").(string) {
+		id_attribute = d.Get("id_attribute").(string)
+	}
 
-  /* Allow user to specify the ID manually */
-  id := d.Get("object_id").(string)
-  if id == "" {
-    /* If not specified, see if terraform has an ID */
-    id = d.Id()
-  }
+	/* Allow user to specify the ID manually */
+	id := d.Get("object_id").(string)
+	if id == "" {
+		/* If not specified, see if terraform has an ID */
+		id = d.Id()
+	}
 
-  log.Printf("common.go: make_api_object routine called for id '%s'\n", id)
+	log.Printf("common.go: make_api_object routine called for id '%s'\n", id)
 
-  if "" != d.Get("create_path")  { post_path   = d.Get("create_path").(string) }
-  if "" != d.Get("read_path")    { get_path    = d.Get("read_path").(string) }
-  if "" != d.Get("update_path")  { put_path    = d.Get("update_path").(string) }
-  if "" != d.Get("destroy_path") { delete_path = d.Get("destroy_path").(string) }
+	if "" != d.Get("create_path") {
+		post_path = d.Get("create_path").(string)
+	}
+	if "" != d.Get("read_path") {
+		get_path = d.Get("read_path").(string)
+	}
+	if "" != d.Get("update_path") {
+		put_path = d.Get("update_path").(string)
+	}
+	if "" != d.Get("destroy_path") {
+		delete_path = d.Get("destroy_path").(string)
+	}
 
-  obj, err := NewAPIObject (
-    m.(*api_client),
-    get_path,
-    post_path,
-    put_path,
-    delete_path,
-    id,
-    id_attribute,
-    d.Get("data").(string),
-    d.Get("debug").(bool),
-  )
-  return obj, err
+	obj, err := NewAPIObject(
+		m.(*api_client),
+		get_path,
+		post_path,
+		put_path,
+		delete_path,
+		id,
+		id_attribute,
+		d.Get("data").(string),
+		d.Get("debug").(bool),
+	)
+	return obj, err
 }
 
 /* After any operation that returns API data, we'll stuff
    all the k,v pairs into the api_data map so users can
    consume the values elsewhere if they'd like */
 func set_resource_state(obj *api_object, d *schema.ResourceData) {
-  api_data := make(map[string]string)
-  for k, v := range obj.api_data {
-    api_data[k] = fmt.Sprintf("%v", v)
-  }
-  d.Set("api_data", api_data)
+	api_data := make(map[string]string)
+	for k, v := range obj.api_data {
+		api_data[k] = fmt.Sprintf("%v", v)
+	}
+	d.Set("api_data", api_data)
 }
 
 /* Using GetObjectAtKey, this function verifies the resulting
    object is either a JSON string or Number and returns it as a string */
 func GetStringAtKey(data map[string]interface{}, path string, debug bool) (string, error) {
-  res, err := GetObjectAtKey(data, path, debug)
-  if err != nil { return "", err }
+	res, err := GetObjectAtKey(data, path, debug)
+	if err != nil {
+		return "", err
+	}
 
-  /* JSON supports strings, numbers, objects and arrays. Allow a string OR number here */
-  t := fmt.Sprintf("%T", res)
-  if t != "string" && t != "float64" {
-    return "", fmt.Errorf("Object at path '%s' is not a JSON string or number (float64). The go fmt package says it is '%T'", path, res)
-  }
+	/* JSON supports strings, numbers, objects and arrays. Allow a string OR number here */
+	t := fmt.Sprintf("%T", res)
+	if t != "string" && t != "float64" {
+		return "", fmt.Errorf("Object at path '%s' is not a JSON string or number (float64). The go fmt package says it is '%T'", path, res)
+	}
 
-  /* Since it might be a number, coax it to a string with fmt */
-  return fmt.Sprintf("%v", res), nil
+	/* Since it might be a number, coax it to a string with fmt */
+	return fmt.Sprintf("%v", res), nil
 }
 
 /* Handy helper that will dig through a map and find something
-   at the defined key. The returned data is not type checked
-   Example:
-   Given:
-   {
-     "attrs": {
-       "id": 1234
-     },
-     "config": {
-       "foo": "abc",
-       "bar": "xyz"
-     }
-  }
-
-  Result:
-  attrs/id => 1234
-  config/foo => "abc"
-*/
-func GetObjectAtKey(data map[string]interface{}, path string, debug bool) (interface{}, error) {
-  hash := data
-
-  parts := strings.Split(path, "/")
-  part := ""
-  seen := ""
-  if debug { log.Printf("common.go:GetObjectAtKey: Locating results_key in parts: %v...", parts) }
-
-  for len(parts) > 1 {
-    /* AKA, Slice...*/
-    part, parts = parts[0], parts[1:]
-
-    /* Protect against double slashes by mistake */
-    if "" == part { continue }
-
-    /* See if this key exists in the hash at this point */
-    if _, ok := hash[part]; ok {
-      if debug { log.Printf("common.go:GetObjectAtKey:  %s - exists", part) }
-      seen += "/" + part
-      if tmp, ok := hash[part].(map[string]interface{});ok {
-        if debug { log.Printf("common.go:GetObjectAtKey:    %s - is a map", part) }
-        hash = tmp
-      } else if tmp, ok := hash[part].([]interface{}); ok {
-        if debug { log.Printf("common.go:GetObjectAtKey:    %s - is a list", part) }
-        mapString := make(map[string]interface{})
-        for key, value := range tmp {
-          strKey := fmt.Sprintf("%v", key)
-          mapString[strKey] = value
-        }
-        hash = mapString
-      } else {
-        if debug { log.Printf("common.go:GetObjectAtKey:    %s - is a %T", part, hash[part]) }
-        return nil, fmt.Errorf("GetObjectAtKey: Object at '%s' is not a map. Is this the right path?", seen)
-      }
-    } else {
-      if debug { log.Printf("common.go:GetObjectAtKey:  %s - MISSING", part) }
-      return nil, fmt.Errorf("GetObjectAtKey: Failed to find '%s' in returned data structure after finding '%s'. Available: %s", part, seen, strings.Join(GetKeys(hash), ","))
-    }
-  } /* End Loop through parts */
-
-  /* We have found the containing map of the value we want */
-  part, parts = parts[0], parts[1:] /* One last time */
-  if _, ok := hash[part]; !ok {
-    if debug {
-      log.Printf("common.go:GetObjectAtKey:  %s - MISSING (available: %s)", part, strings.Join(GetKeys(hash), ","))
-    }
-    return nil, fmt.Errorf("GetObjectAtKey: Resulting map at '%s' does not have key '%s'. Available: %s", seen, part, strings.Join(GetKeys(hash), ","))
-  }
-
-  if debug { log.Printf("common.go:GetObjectAtKey:  %s - exists", part) }
-
-  return hash[part], nil
+ at the defined key. The returned data is not type checked
+ Example:
+ Given:
+ {
+   "attrs": {
+     "id": 1234
+   },
+   "config": {
+     "foo": "abc",
+     "bar": "xyz"
+   }
 }
 
+Result:
+attrs/id => 1234
+config/foo => "abc"
+*/
+func GetObjectAtKey(data map[string]interface{}, path string, debug bool) (interface{}, error) {
+	hash := data
+
+	parts := strings.Split(path, "/")
+	part := ""
+	seen := ""
+	if debug {
+		log.Printf("common.go:GetObjectAtKey: Locating results_key in parts: %v...", parts)
+	}
+
+	for len(parts) > 1 {
+		/* AKA, Slice...*/
+		part, parts = parts[0], parts[1:]
+
+		/* Protect against double slashes by mistake */
+		if "" == part {
+			continue
+		}
+
+		/* See if this key exists in the hash at this point */
+		if _, ok := hash[part]; ok {
+			if debug {
+				log.Printf("common.go:GetObjectAtKey:  %s - exists", part)
+			}
+			seen += "/" + part
+			if tmp, ok := hash[part].(map[string]interface{}); ok {
+				if debug {
+					log.Printf("common.go:GetObjectAtKey:    %s - is a map", part)
+				}
+				hash = tmp
+			} else if tmp, ok := hash[part].([]interface{}); ok {
+				if debug {
+					log.Printf("common.go:GetObjectAtKey:    %s - is a list", part)
+				}
+				mapString := make(map[string]interface{})
+				for key, value := range tmp {
+					strKey := fmt.Sprintf("%v", key)
+					mapString[strKey] = value
+				}
+				hash = mapString
+			} else {
+				if debug {
+					log.Printf("common.go:GetObjectAtKey:    %s - is a %T", part, hash[part])
+				}
+				return nil, fmt.Errorf("GetObjectAtKey: Object at '%s' is not a map. Is this the right path?", seen)
+			}
+		} else {
+			if debug {
+				log.Printf("common.go:GetObjectAtKey:  %s - MISSING", part)
+			}
+			return nil, fmt.Errorf("GetObjectAtKey: Failed to find '%s' in returned data structure after finding '%s'. Available: %s", part, seen, strings.Join(GetKeys(hash), ","))
+		}
+	} /* End Loop through parts */
+
+	/* We have found the containing map of the value we want */
+	part, parts = parts[0], parts[1:] /* One last time */
+	if _, ok := hash[part]; !ok {
+		if debug {
+			log.Printf("common.go:GetObjectAtKey:  %s - MISSING (available: %s)", part, strings.Join(GetKeys(hash), ","))
+		}
+		return nil, fmt.Errorf("GetObjectAtKey: Resulting map at '%s' does not have key '%s'. Available: %s", seen, part, strings.Join(GetKeys(hash), ","))
+	}
+
+	if debug {
+		log.Printf("common.go:GetObjectAtKey:  %s - exists", part)
+	}
+
+	return hash[part], nil
+}
 
 /* Handy helper to just dump the keys of a map into a slice */
 func GetKeys(hash map[string]interface{}) []string {
-  keys := make([]string, 0)
-  for k := range hash {
-    keys = append(keys, k)
-  }
-  return keys
+	keys := make([]string, 0)
+	for k := range hash {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/restapi/common_test.go
+++ b/restapi/common_test.go
@@ -1,55 +1,59 @@
 package restapi
 
 import (
-  "testing"
-  "encoding/json"
-  "fmt"
-  "strings"
-  "github.com/hashicorp/terraform/helper/resource"
-  "github.com/hashicorp/terraform/terraform"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"strings"
+	"testing"
 )
 
 func testAccCheckRestapiObjectExists(n string, id string, client *api_client) resource.TestCheckFunc {
-  return func(s *terraform.State) error {
-    rs, ok := s.RootModule().Resources[n]
-    if !ok {
-      keys := make([]string, 0, len(s.RootModule().Resources))
-      for k := range s.RootModule().Resources {
-        keys = append(keys, k)
-      }
-      return fmt.Errorf("RestAPI object not found in terraform state: %s. Found: %s", n, strings.Join(keys, ", "))
-    }
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			keys := make([]string, 0, len(s.RootModule().Resources))
+			for k := range s.RootModule().Resources {
+				keys = append(keys, k)
+			}
+			return fmt.Errorf("RestAPI object not found in terraform state: %s. Found: %s", n, strings.Join(keys, ", "))
+		}
 
-    if rs.Primary.ID == "" {
-      return fmt.Errorf("RestAPI object id not set in terraform")
-    }
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("RestAPI object id not set in terraform")
+		}
 
-    /* Make a throw-away API object to read from the API */
-    path := "/api/objects"
-    obj, err := NewAPIObject (
-      client,
-      path + "/{id}",
-      path,
-      path + "/{id}",
-      path + "/{id}",
-      id,
-      "id",
-      "{}",
-      true,
-    )
-    if err != nil { return err }
+		/* Make a throw-away API object to read from the API */
+		path := "/api/objects"
+		obj, err := NewAPIObject(
+			client,
+			path+"/{id}",
+			path,
+			path+"/{id}",
+			path+"/{id}",
+			id,
+			"id",
+			"{}",
+			true,
+		)
+		if err != nil {
+			return err
+		}
 
-    err = obj.read_object()
-    if err != nil { return err }
+		err = obj.read_object()
+		if err != nil {
+			return err
+		}
 
-    return nil
-  }
+		return nil
+	}
 }
 
 func TestGetStringAtKey(t *testing.T) {
-  debug := false
-  test_obj := make(map[string]interface{})
-  err := json.Unmarshal([]byte(`
+	debug := false
+	test_obj := make(map[string]interface{})
+	err := json.Unmarshal([]byte(`
     {
       "rootFoo": "bar",
       "top": {
@@ -67,48 +71,50 @@ func TestGetStringAtKey(t *testing.T) {
       }
     }
   `), &test_obj)
-  if nil != err { t.Fatalf("Error unmarshalling JSON: %s", err) }
+	if nil != err {
+		t.Fatalf("Error unmarshalling JSON: %s", err)
+	}
 
-  var res string
+	var res string
 
-  res, err = GetStringAtKey(test_obj, "rootFoo", debug)
-  if err != nil {
-    t.Fatalf("Error extracting 'rootFoo' from JSON payload: %s", err)
-  } else if "bar" != res {
-    t.Fatalf("Error: Expected 'bar', but got %s", res)
-  }
+	res, err = GetStringAtKey(test_obj, "rootFoo", debug)
+	if err != nil {
+		t.Fatalf("Error extracting 'rootFoo' from JSON payload: %s", err)
+	} else if "bar" != res {
+		t.Fatalf("Error: Expected 'bar', but got %s", res)
+	}
 
-  res, err = GetStringAtKey(test_obj, "top/foo", debug)
-  if err != nil {
-    t.Fatalf("Error extracting 'top/foo' from JSON payload: %s", err)
-  } else if "bar" != res {
-    t.Fatalf("Error: Expected 'bar', but got %s", res)
-  }
+	res, err = GetStringAtKey(test_obj, "top/foo", debug)
+	if err != nil {
+		t.Fatalf("Error extracting 'top/foo' from JSON payload: %s", err)
+	} else if "bar" != res {
+		t.Fatalf("Error: Expected 'bar', but got %s", res)
+	}
 
-  res, err = GetStringAtKey(test_obj, "top/middle/bottom/foo", debug)
-  if err != nil {
-    t.Fatalf("Error extracting top/foo from JSON payload: %s", err)
-  } else if "bar" != res {
-    t.Fatalf("Error: Expected 'bar', but got %s", res)
-  }
+	res, err = GetStringAtKey(test_obj, "top/middle/bottom/foo", debug)
+	if err != nil {
+		t.Fatalf("Error extracting top/foo from JSON payload: %s", err)
+	} else if "bar" != res {
+		t.Fatalf("Error: Expected 'bar', but got %s", res)
+	}
 
-  res, err = GetStringAtKey(test_obj, "top/middle/junk", debug)
-  if err == nil {
-    t.Fatalf("Error expected when trying to extract 'top/middle/junk' from payload")
-  }
+	res, err = GetStringAtKey(test_obj, "top/middle/junk", debug)
+	if err == nil {
+		t.Fatalf("Error expected when trying to extract 'top/middle/junk' from payload")
+	}
 
-  res, err = GetStringAtKey(test_obj, "top/number", debug)
-  if err != nil {
-    t.Fatalf("Error extracting 'top/number' from JSON payload: %s", err)
-  } else if "1" != res {
-    t.Fatalf("Error: Expected '1', but got %s", res)
-  }
+	res, err = GetStringAtKey(test_obj, "top/number", debug)
+	if err != nil {
+		t.Fatalf("Error extracting 'top/number' from JSON payload: %s", err)
+	} else if "1" != res {
+		t.Fatalf("Error: Expected '1', but got %s", res)
+	}
 }
 
 func TestGetListStringAtKey(t *testing.T) {
-  debug := false
-  test_obj := make(map[string]interface{})
-  err := json.Unmarshal([]byte(`
+	debug := false
+	test_obj := make(map[string]interface{})
+	err := json.Unmarshal([]byte(`
     {
       "rootFoo": "bar",
       "items": [
@@ -124,30 +130,30 @@ func TestGetListStringAtKey(t *testing.T) {
       ]
     }
   `), &test_obj)
-  if nil != err {
-    t.Fatalf("Error unmarshalling JSON: %s", err)
-  }
+	if nil != err {
+		t.Fatalf("Error unmarshalling JSON: %s", err)
+	}
 
-  var res string
+	var res string
 
-  res, err = GetStringAtKey(test_obj, "items/0/resource/id", debug)
-  if err != nil {
-    t.Fatalf("Error extracting 'resource' from JSON payload: %s", err)
-  } else if "123" != res {
-    t.Fatalf("Error: Expected '123', but got %s", res)
-  }
+	res, err = GetStringAtKey(test_obj, "items/0/resource/id", debug)
+	if err != nil {
+		t.Fatalf("Error extracting 'resource' from JSON payload: %s", err)
+	} else if "123" != res {
+		t.Fatalf("Error: Expected '123', but got %s", res)
+	}
 
-  res, err = GetStringAtKey(test_obj, "items/0/test/1/id", debug)
-  if err != nil {
-    t.Fatalf("Error extracting 'resource' from JSON payload: %s", err)
-  } else if "1337" != res {
-    t.Fatalf("Error: Expected '1337', but got %s", res)
-  }
+	res, err = GetStringAtKey(test_obj, "items/0/test/1/id", debug)
+	if err != nil {
+		t.Fatalf("Error extracting 'resource' from JSON payload: %s", err)
+	} else if "1337" != res {
+		t.Fatalf("Error: Expected '1337', but got %s", res)
+	}
 
-  res, err = GetStringAtKey(test_obj, "items/0/list_numbers/1", debug)
-  if err != nil {
-    t.Fatalf("Error extracting 'resource' from JSON payload: %s", err)
-  } else if "2" != res {
-    t.Fatalf("Error: Expected '2', but got %s", res)
-  }
+	res, err = GetStringAtKey(test_obj, "items/0/list_numbers/1", debug)
+	if err != nil {
+		t.Fatalf("Error extracting 'resource' from JSON payload: %s", err)
+	} else if "2" != res {
+		t.Fatalf("Error: Expected '2', but got %s", res)
+	}
 }

--- a/restapi/datasource_api_object.go
+++ b/restapi/datasource_api_object.go
@@ -1,195 +1,218 @@
 package restapi
 
 import (
-  "github.com/hashicorp/terraform/helper/schema"
-  "fmt"
-  "errors"
-  "log"
-  "encoding/json"
-  "reflect"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"reflect"
 )
 
 func dataSourceRestApi() *schema.Resource {
-  return &schema.Resource{
-    Read:   dataSourceRestApiRead,
+	return &schema.Resource{
+		Read: dataSourceRestApiRead,
 
-    Schema: map[string]*schema.Schema{
-      "path": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "The API path on top of the base URL set in the provider that represents objects of this type on the API server.",
-        Required:    true,
-      },
-      "query_string": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "An optional query string to send when performing the search.",
-        Optional:    true,
-      },
-      "search_key": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "When reading search results from the API, this key is used to identify the specific record to read. This should be a unique record such as 'name'. Similar to results_key, the value may be in the format of 'field/field/field' to search for data deeper in the returned object.",
-        Required:    true,
-      },
-      "search_value": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "The value of 'search_key' will be compared to this value to determine if the correct object was found. Example: if 'search_key' is 'name' and 'search_value' is 'foo', the record in the array returned by the API with name=foo will be used.",
-        Required:    true,
-      },
-      "results_key": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "When issuing a GET to the path, this JSON key is used to locate the results array. The format is 'field/field/field'. Example: 'results/values'. If omitted, it is assumed the results coming back are already an array and are to be used exactly as-is.",
-        Optional:    true,
-      },
-      "id_attribute": &schema.Schema{
-        Type: schema.TypeString,
-        Description: "Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)",
-        Optional: true,
-      },
-      "debug": &schema.Schema{
-        Type:        schema.TypeBool,
-        Description: "Whether to emit verbose debug output while working with the API object on the server.",
-        Optional:    true,
-      },
-      "api_data": &schema.Schema{
-        Type:        schema.TypeMap,
-	Elem:        &schema.Schema{ Type: schema.TypeString },
-        Description: "After data from the API server is read, this map will include k/v pairs usable in other terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).",
-	Computed:    true,
-      },
-    }, /* End schema */
+		Schema: map[string]*schema.Schema{
+			"path": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The API path on top of the base URL set in the provider that represents objects of this type on the API server.",
+				Required:    true,
+			},
+			"query_string": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "An optional query string to send when performing the search.",
+				Optional:    true,
+			},
+			"search_key": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "When reading search results from the API, this key is used to identify the specific record to read. This should be a unique record such as 'name'. Similar to results_key, the value may be in the format of 'field/field/field' to search for data deeper in the returned object.",
+				Required:    true,
+			},
+			"search_value": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The value of 'search_key' will be compared to this value to determine if the correct object was found. Example: if 'search_key' is 'name' and 'search_value' is 'foo', the record in the array returned by the API with name=foo will be used.",
+				Required:    true,
+			},
+			"results_key": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "When issuing a GET to the path, this JSON key is used to locate the results array. The format is 'field/field/field'. Example: 'results/values'. If omitted, it is assumed the results coming back are already an array and are to be used exactly as-is.",
+				Optional:    true,
+			},
+			"id_attribute": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)",
+				Optional:    true,
+			},
+			"debug": &schema.Schema{
+				Type:        schema.TypeBool,
+				Description: "Whether to emit verbose debug output while working with the API object on the server.",
+				Optional:    true,
+			},
+			"api_data": &schema.Schema{
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "After data from the API server is read, this map will include k/v pairs usable in other terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).",
+				Computed:    true,
+			},
+		}, /* End schema */
 
-  }
+	}
 }
 
-
 func dataSourceRestApiRead(d *schema.ResourceData, meta interface{}) error {
-  path := d.Get("path").(string)
-  query_string := d.Get("query_string").(string)
-  debug := d.Get("debug").(bool)
-  client := meta.(*api_client)
-  if debug { log.Printf("datasource_api_object.go: Data routine called.") }
+	path := d.Get("path").(string)
+	query_string := d.Get("query_string").(string)
+	debug := d.Get("debug").(bool)
+	client := meta.(*api_client)
+	if debug {
+		log.Printf("datasource_api_object.go: Data routine called.")
+	}
 
-  search_key   := d.Get("search_key").(string)
-  search_value := d.Get("search_value").(string)
-  results_key  := d.Get("results_key").(string)
+	search_key := d.Get("search_key").(string)
+	search_value := d.Get("search_value").(string)
+	results_key := d.Get("results_key").(string)
 
-  /* Allow user to override provider-level id_attribute */
-  id_attribute := client.id_attribute
-  if "" != d.Get("id_attribute").(string) {
-    id_attribute = d.Get("id_attribute").(string)
-  }
+	/* Allow user to override provider-level id_attribute */
+	id_attribute := client.id_attribute
+	if "" != d.Get("id_attribute").(string) {
+		id_attribute = d.Get("id_attribute").(string)
+	}
 
-  if debug { log.Printf("datasource_api_object.go:\npath: %s\nquery_string: %s\nsearch_key: %s\nsearch_value: %s\nresults_key: %s\nid_attribute: %s", path, query_string, search_key, search_value, results_key, id_attribute) }
+	if debug {
+		log.Printf("datasource_api_object.go:\npath: %s\nquery_string: %s\nsearch_key: %s\nsearch_value: %s\nresults_key: %s\nid_attribute: %s", path, query_string, search_key, search_value, results_key, id_attribute)
+	}
 
-  id := ""
-  var data_array []interface{}
-  var ok bool
+	id := ""
+	var data_array []interface{}
+	var ok bool
 
-  /*
-    Issue a GET to the base path and expect results to come back
-  */
-  search_path := path
-  if "" != query_string {
-    if debug { log.Printf("datasource_api_object.go: Adding query string '%s'", query_string) }
-    search_path = fmt.Sprintf("%s?%s", search_path, query_string)
-  }
+	/*
+	   Issue a GET to the base path and expect results to come back
+	*/
+	search_path := path
+	if "" != query_string {
+		if debug {
+			log.Printf("datasource_api_object.go: Adding query string '%s'", query_string)
+		}
+		search_path = fmt.Sprintf("%s?%s", search_path, query_string)
+	}
 
-  if debug { log.Printf("datasource_api_object.go: Calling API on path '%s'", search_path) }
-  res_str, err := client.send_request("GET", search_path, "")
-  if err != nil { return err }
+	if debug {
+		log.Printf("datasource_api_object.go: Calling API on path '%s'", search_path)
+	}
+	res_str, err := client.send_request("GET", search_path, "")
+	if err != nil {
+		return err
+	}
 
-  /*
-    Parse it seeking JSON data
-  */
-  if debug { log.Printf("datasource_api_object.go: Response recieved... parsing") }
-  var result interface{}
-  err = json.Unmarshal([]byte(res_str), &result)
-  if err != nil { return err }
+	/*
+	   Parse it seeking JSON data
+	*/
+	if debug {
+		log.Printf("datasource_api_object.go: Response recieved... parsing")
+	}
+	var result interface{}
+	err = json.Unmarshal([]byte(res_str), &result)
+	if err != nil {
+		return err
+	}
 
-  if "" != results_key {
-    var tmp interface{}
+	if "" != results_key {
+		var tmp interface{}
 
-    if debug { log.Printf("datasource_api_object.go: Locating '%s' in the results", results_key) }
+		if debug {
+			log.Printf("datasource_api_object.go: Locating '%s' in the results", results_key)
+		}
 
-    /* First verify the data we got back is a hash */
-    if _, ok = result.(map[string]interface{}); !ok {
-      return fmt.Errorf("datasource_api_object.go: The results of a GET to '%s' did not return a hash. Cannot search within for results_key '%s'", search_path, results_key)
-    }
+		/* First verify the data we got back is a hash */
+		if _, ok = result.(map[string]interface{}); !ok {
+			return fmt.Errorf("datasource_api_object.go: The results of a GET to '%s' did not return a hash. Cannot search within for results_key '%s'", search_path, results_key)
+		}
 
-    tmp, err = GetObjectAtKey(result.(map[string]interface{}), results_key, debug)
-    if err != nil {
-      return fmt.Errorf("datasource_api_object.go: Error finding results_key: %s", err)
-    }
-    if data_array, ok = tmp.([]interface{}); !ok {
-      return fmt.Errorf("datasource_api_object.go: The data at results_key location '%s' is not an array. It is a '%s'", results_key, reflect.TypeOf(tmp))
-    }
-  } else {
-    if debug { log.Printf("datasource_api_object.go: results_key is not set - coaxing data to array of interfaces") }
-    if data_array, ok = result.([]interface{}); !ok {
-      return fmt.Errorf("datasource_api_object.go: The results of a GET to '%s' did not return an array. It is a '%s'. Perhaps you meant to add a results_key?", search_path, reflect.TypeOf(result))
-    }
-  }
+		tmp, err = GetObjectAtKey(result.(map[string]interface{}), results_key, debug)
+		if err != nil {
+			return fmt.Errorf("datasource_api_object.go: Error finding results_key: %s", err)
+		}
+		if data_array, ok = tmp.([]interface{}); !ok {
+			return fmt.Errorf("datasource_api_object.go: The data at results_key location '%s' is not an array. It is a '%s'", results_key, reflect.TypeOf(tmp))
+		}
+	} else {
+		if debug {
+			log.Printf("datasource_api_object.go: results_key is not set - coaxing data to array of interfaces")
+		}
+		if data_array, ok = result.([]interface{}); !ok {
+			return fmt.Errorf("datasource_api_object.go: The results of a GET to '%s' did not return an array. It is a '%s'. Perhaps you meant to add a results_key?", search_path, reflect.TypeOf(result))
+		}
+	}
 
-  /* Loop through all of the results seeking the specific record */
-  for _, item := range data_array {
-    var hash map[string]interface{}
+	/* Loop through all of the results seeking the specific record */
+	for _, item := range data_array {
+		var hash map[string]interface{}
 
-    if hash, ok = item.(map[string]interface{}); !ok {
-      return fmt.Errorf("datasource_api_object.go: The elements being searched for data are not a map of key value pairs.")
-    }
+		if hash, ok = item.(map[string]interface{}); !ok {
+			return fmt.Errorf("datasource_api_object.go: The elements being searched for data are not a map of key value pairs.")
+		}
 
-    if debug {
-      log.Printf("datasource_api_object.go: Examining %v", hash)
-      log.Printf("datasource_api_object.go:   Comparing '%s' to the value in '%s'", search_value, search_key)
-    }
+		if debug {
+			log.Printf("datasource_api_object.go: Examining %v", hash)
+			log.Printf("datasource_api_object.go:   Comparing '%s' to the value in '%s'", search_value, search_key)
+		}
 
-    tmp, err := GetStringAtKey(hash, search_key, debug)
-    if err != nil {
-      return(fmt.Errorf("Failed to get the value of '%s' in the results array at '%s': %s", search_key, results_key, err))
-    }
+		tmp, err := GetStringAtKey(hash, search_key, debug)
+		if err != nil {
+			return (fmt.Errorf("Failed to get the value of '%s' in the results array at '%s': %s", search_key, results_key, err))
+		}
 
-    /* We found our record */
-    if tmp == search_value {
-      id, err = GetStringAtKey(hash, id_attribute, debug)
-      if err != nil {
-        return(fmt.Errorf("Failed to find id_attribute '%s' in the record: %s", id_attribute, err))
-      }
+		/* We found our record */
+		if tmp == search_value {
+			id, err = GetStringAtKey(hash, id_attribute, debug)
+			if err != nil {
+				return (fmt.Errorf("Failed to find id_attribute '%s' in the record: %s", id_attribute, err))
+			}
 
-      if debug { log.Printf("datasource_api_object.go:   Found ID '%s'", id) }
+			if debug {
+				log.Printf("datasource_api_object.go:   Found ID '%s'", id)
+			}
 
-      /* But there is no id attribute??? */
-      if "" == id {
-        return(errors.New(fmt.Sprintf("The object for '%s'='%s' did not have the id attribute '%s', or the value was empty.", search_key, search_value, id_attribute)))
-      }
-      break
-    }
-  }
+			/* But there is no id attribute??? */
+			if "" == id {
+				return (errors.New(fmt.Sprintf("The object for '%s'='%s' did not have the id attribute '%s', or the value was empty.", search_key, search_value, id_attribute)))
+			}
+			break
+		}
+	}
 
-  if "" == id {
-    return(fmt.Errorf("Failed to find an object with the '%s' key = '%s' at %s", search_key, search_value, search_path))
-  }
+	if "" == id {
+		return (fmt.Errorf("Failed to find an object with the '%s' key = '%s' at %s", search_key, search_value, search_path))
+	}
 
-  /* Back to terraform-specific stuff. Create an api_object with the ID and refresh it object */
-  if debug { log.Printf("datasource_api_object.go: Attempting to construct api_object to refresh data") }
-  obj, err := NewAPIObject (
-    client,
-    path + "/{id}",
-    path,
-    path + "/{id}",
-    path + "/{id}",
-    id,
-    id_attribute,
-    "{}",
-    debug,
-  )
-  if err != nil { return err }
-  d.SetId(obj.id)
+	/* Back to terraform-specific stuff. Create an api_object with the ID and refresh it object */
+	if debug {
+		log.Printf("datasource_api_object.go: Attempting to construct api_object to refresh data")
+	}
+	obj, err := NewAPIObject(
+		client,
+		path+"/{id}",
+		path,
+		path+"/{id}",
+		path+"/{id}",
+		id,
+		id_attribute,
+		"{}",
+		debug,
+	)
+	if err != nil {
+		return err
+	}
+	d.SetId(obj.id)
 
-  err = obj.read_object()
-  if err == nil {
-    /* Setting terraform ID tells terraform the object was created or it exists */
-    log.Printf("datasource_api_object.go: Data resource. Returned id is '%s'\n", obj.id);
-    d.SetId(obj.id)
-    set_resource_state(obj, d)
-  }
-  return err
+	err = obj.read_object()
+	if err == nil {
+		/* Setting terraform ID tells terraform the object was created or it exists */
+		log.Printf("datasource_api_object.go: Data resource. Returned id is '%s'\n", obj.id)
+		d.SetId(obj.id)
+		set_resource_state(obj, d)
+	}
+	return err
 }

--- a/restapi/datasource_api_object_test.go
+++ b/restapi/datasource_api_object_test.go
@@ -8,25 +8,27 @@ package restapi
 */
 
 import (
-  "os"
-  "fmt"
-  "testing"
-  "github.com/hashicorp/terraform/helper/resource"
-  "github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"fmt"
+	"github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
 )
 
 func TestAccRestapiobject_Basic(t *testing.T) {
-  debug := false
-  api_server_objects := make(map[string]map[string]interface{})
+	debug := false
+	api_server_objects := make(map[string]map[string]interface{})
 
-  svr := fakeserver.NewFakeServer(8082, api_server_objects, true, debug, "")
-  os.Setenv("REST_API_URI", "http://127.0.0.1:8082")
+	svr := fakeserver.NewFakeServer(8082, api_server_objects, true, debug, "")
+	os.Setenv("REST_API_URI", "http://127.0.0.1:8082")
 
-  client, err := NewAPIClient("http://127.0.0.1:8082/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
-  if err != nil { t.Fatal(err) }
+	client, err := NewAPIClient("http://127.0.0.1:8082/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-  /* Send a simple object */
-  client.send_request("POST", "/api/objects", `
+	/* Send a simple object */
+	client.send_request("POST", "/api/objects", `
     {
       "id": "1234",
       "first": "Foo",
@@ -36,7 +38,7 @@ func TestAccRestapiobject_Basic(t *testing.T) {
       }
     }
   `)
-  client.send_request("POST", "/api/objects", `
+	client.send_request("POST", "/api/objects", `
     {
       "id": "4321",
       "first": "Foo",
@@ -46,7 +48,7 @@ func TestAccRestapiobject_Basic(t *testing.T) {
       }
     }
   `)
-  client.send_request("POST", "/api/objects", `
+	client.send_request("POST", "/api/objects", `
     {
       "id": "5678",
       "first": "Nested",
@@ -57,27 +59,27 @@ func TestAccRestapiobject_Basic(t *testing.T) {
     }
   `)
 
-  /* Send a complex object that we will pretend is the results of a search
-  client.send_request("POST", "/api/objects", `
-    {
-      "id": "people",
-      "results": {
-        "number": 2,
-        "list": [
-          { "id": "1234", "first": "Foo", "last": "Bar" },
-          { "id": "4321", "first": "Foo", "last": "Baz" }
-        ]
-      }
-    }
-  `)
-  */
+	/* Send a complex object that we will pretend is the results of a search
+	client.send_request("POST", "/api/objects", `
+	  {
+	    "id": "people",
+	    "results": {
+	      "number": 2,
+	      "list": [
+	        { "id": "1234", "first": "Foo", "last": "Bar" },
+	        { "id": "4321", "first": "Foo", "last": "Baz" }
+	      ]
+	    }
+	  }
+	`)
+	*/
 
-  resource.UnitTest(t, resource.TestCase{
-    Providers:    testAccProviders,
-    PreCheck:     func() { svr.StartInBackground() },
-    Steps: []resource.TestStep{
-      {
-        Config: fmt.Sprintf(`
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { svr.StartInBackground() },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
             data "restapi_object" "Foo" {
                path = "/api/objects"
                search_key = "last"
@@ -85,15 +87,15 @@ func TestAccRestapiobject_Basic(t *testing.T) {
                debug = %t
             }
           `, debug),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckRestapiObjectExists("data.restapi_object.Foo", "1234", client),
-          resource.TestCheckResourceAttr("data.restapi_object.Foo", "id", "1234"),
-          resource.TestCheckResourceAttr("data.restapi_object.Foo", "api_data.first", "Foo"),
-          resource.TestCheckResourceAttr("data.restapi_object.Foo", "api_data.last", "Bar"),
-        ),
-      },
-      {
-        Config: fmt.Sprintf(`
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRestapiObjectExists("data.restapi_object.Foo", "1234", client),
+					resource.TestCheckResourceAttr("data.restapi_object.Foo", "id", "1234"),
+					resource.TestCheckResourceAttr("data.restapi_object.Foo", "api_data.first", "Foo"),
+					resource.TestCheckResourceAttr("data.restapi_object.Foo", "api_data.last", "Bar"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
             data "restapi_object" "Nested" {
                path = "/api/objects"
                search_key = "data/identifier"
@@ -101,16 +103,16 @@ func TestAccRestapiobject_Basic(t *testing.T) {
                debug = %t
             }
           `, debug),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckRestapiObjectExists("data.restapi_object.Nested", "5678", client),
-          resource.TestCheckResourceAttr("data.restapi_object.Nested", "id", "5678"),
-          resource.TestCheckResourceAttr("data.restapi_object.Nested", "api_data.first", "Nested"),
-          resource.TestCheckResourceAttr("data.restapi_object.Nested", "api_data.last", "Fields"),
-        ),
-      },
-      {
-        /* Similar to the first, but also with a query string */
-        Config: fmt.Sprintf(`
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRestapiObjectExists("data.restapi_object.Nested", "5678", client),
+					resource.TestCheckResourceAttr("data.restapi_object.Nested", "id", "5678"),
+					resource.TestCheckResourceAttr("data.restapi_object.Nested", "api_data.first", "Nested"),
+					resource.TestCheckResourceAttr("data.restapi_object.Nested", "api_data.last", "Fields"),
+				),
+			},
+			{
+				/* Similar to the first, but also with a query string */
+				Config: fmt.Sprintf(`
             data "restapi_object" "Baz" {
                path = "/api/objects"
                query_string = "someArg=foo&anotherArg=bar"
@@ -119,35 +121,35 @@ func TestAccRestapiobject_Basic(t *testing.T) {
                debug = %t
             }
           `, debug),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckRestapiObjectExists("data.restapi_object.Baz", "4321", client),
-          resource.TestCheckResourceAttr("data.restapi_object.Baz", "id", "4321"),
-          resource.TestCheckResourceAttr("data.restapi_object.Baz", "api_data.first", "Foo"),
-          resource.TestCheckResourceAttr("data.restapi_object.Baz", "api_data.last", "Baz"),
-        ),
-      },
-/* TODO: Fails with fakeserver because a request for /api/objects/people/4321 is unexpected (400 error)
-         Find a way to test this effectively
-      {
-        Config: fmt.Sprintf(`
-            data "restapi_object" "Baz" {
-               path = "/api/objects/people"
-               search_key = "last"
-               search_value = "Baz"
-               results_key = "results/list"
-               debug = %t
-            }
-          `, debug),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckRestapiObjectExists("data.restapi_object.Baz", "4321", client),
-          resource.TestCheckResourceAttr("data.restapi_object.Baz", "id", "4321"),
-          resource.TestCheckResourceAttr("data.restapi_object.Baz", "api_data.first", "Foo"),
-          resource.TestCheckResourceAttr("data.restapi_object.Baz", "api_data.last", "Baz"),
-        ),
-      },
-*/
-    },
-  })
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRestapiObjectExists("data.restapi_object.Baz", "4321", client),
+					resource.TestCheckResourceAttr("data.restapi_object.Baz", "id", "4321"),
+					resource.TestCheckResourceAttr("data.restapi_object.Baz", "api_data.first", "Foo"),
+					resource.TestCheckResourceAttr("data.restapi_object.Baz", "api_data.last", "Baz"),
+				),
+			},
+			/* TODO: Fails with fakeserver because a request for /api/objects/people/4321 is unexpected (400 error)
+			      Find a way to test this effectively
+			   {
+			     Config: fmt.Sprintf(`
+			         data "restapi_object" "Baz" {
+			            path = "/api/objects/people"
+			            search_key = "last"
+			            search_value = "Baz"
+			            results_key = "results/list"
+			            debug = %t
+			         }
+			       `, debug),
+			     Check: resource.ComposeTestCheckFunc(
+			       testAccCheckRestapiObjectExists("data.restapi_object.Baz", "4321", client),
+			       resource.TestCheckResourceAttr("data.restapi_object.Baz", "id", "4321"),
+			       resource.TestCheckResourceAttr("data.restapi_object.Baz", "api_data.first", "Foo"),
+			       resource.TestCheckResourceAttr("data.restapi_object.Baz", "api_data.last", "Baz"),
+			     ),
+			   },
+			*/
+		},
+	})
 
-  svr.Shutdown()
+	svr.Shutdown()
 }

--- a/restapi/datasource_api_object_test.go
+++ b/restapi/datasource_api_object_test.go
@@ -22,7 +22,20 @@ func TestAccRestapiobject_Basic(t *testing.T) {
 	svr := fakeserver.NewFakeServer(8082, api_server_objects, true, debug, "")
 	os.Setenv("REST_API_URI", "http://127.0.0.1:8082")
 
-	client, err := NewAPIClient("http://127.0.0.1:8082/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
+	opt := &apiClientOpt{
+		uri:                   "http://127.0.0.1:8082/",
+		insecure:              false,
+		username:              "",
+		password:              "",
+		headers:               make(map[string]string, 0),
+		timeout:               2,
+		id_attribute:          "id",
+		copy_keys:             make([]string, 0),
+		write_returns_object:  false,
+		create_returns_object: false,
+		debug:                 debug,
+	}
+	client, err := NewAPIClient(opt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/restapi/import_api_object_test.go
+++ b/restapi/import_api_object_test.go
@@ -1,44 +1,46 @@
 package restapi
 
 import (
-  "os"
-  "testing"
-  "github.com/hashicorp/terraform/helper/resource"
-  "github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
 )
 
 func TestAccRestApiObject_importBasic(t *testing.T) {
-  debug := false
-  api_server_objects := make(map[string]map[string]interface{})
+	debug := false
+	api_server_objects := make(map[string]map[string]interface{})
 
-  svr := fakeserver.NewFakeServer(8082, api_server_objects, true, debug, "")
-  os.Setenv("REST_API_URI", "http://127.0.0.1:8082")
+	svr := fakeserver.NewFakeServer(8082, api_server_objects, true, debug, "")
+	os.Setenv("REST_API_URI", "http://127.0.0.1:8082")
 
-  client, err := NewAPIClient("http://127.0.0.1:8082/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
-  if err != nil { t.Fatal(err) }
-  client.send_request("POST", "/api/objects", `{ "id": "1234", "first": "Foo", "last": "Bar" }`)
+	client, err := NewAPIClient("http://127.0.0.1:8082/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.send_request("POST", "/api/objects", `{ "id": "1234", "first": "Foo", "last": "Bar" }`)
 
-  resource.UnitTest(t, resource.TestCase{
-    Providers:    testAccProviders,
-    PreCheck:     func() { svr.StartInBackground() },
-    Steps: []resource.TestStep{
-      {
-        Config: generate_test_resource(
-          "Foo",
-          `{ "id": "1234", "first": "Foo", "last": "Bar" }`,
-          make(map[string]interface{}),
-        ),
-      },
-      {
-        ResourceName: "restapi_object.Foo",
-        ImportState: true,
-        ImportStateId: "1234",
-        ImportStateIdPrefix: "/api/objects/",
-        ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{ "debug", "data" },
-      },
-    },
-  })
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { svr.StartInBackground() },
+		Steps: []resource.TestStep{
+			{
+				Config: generate_test_resource(
+					"Foo",
+					`{ "id": "1234", "first": "Foo", "last": "Bar" }`,
+					make(map[string]interface{}),
+				),
+			},
+			{
+				ResourceName:            "restapi_object.Foo",
+				ImportState:             true,
+				ImportStateId:           "1234",
+				ImportStateIdPrefix:     "/api/objects/",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"debug", "data"},
+			},
+		},
+	})
 
-  svr.Shutdown()
+	svr.Shutdown()
 }

--- a/restapi/import_api_object_test.go
+++ b/restapi/import_api_object_test.go
@@ -14,7 +14,20 @@ func TestAccRestApiObject_importBasic(t *testing.T) {
 	svr := fakeserver.NewFakeServer(8082, api_server_objects, true, debug, "")
 	os.Setenv("REST_API_URI", "http://127.0.0.1:8082")
 
-	client, err := NewAPIClient("http://127.0.0.1:8082/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
+	opt := &apiClientOpt{
+		uri:                   "http://127.0.0.1:8082/",
+		insecure:              false,
+		username:              "",
+		password:              "",
+		headers:               make(map[string]string, 0),
+		timeout:               2,
+		id_attribute:          "id",
+		copy_keys:             make([]string, 0),
+		write_returns_object:  false,
+		create_returns_object: false,
+		debug:                 debug,
+	}
+	client, err := NewAPIClient(opt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/restapi/provider.go
+++ b/restapi/provider.go
@@ -1,138 +1,138 @@
 package restapi
 
 import (
- "github.com/hashicorp/terraform/helper/schema"
- "github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func Provider() terraform.ResourceProvider {
-  return &schema.Provider{
-    Schema: map[string]*schema.Schema{
-      "uri": &schema.Schema{
-        Type: schema.TypeString,
-        Required: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_URI", nil),
-        Description: "URI of the REST API endpoint. This serves as the base of all requests.",
-      },
-      "insecure": &schema.Schema{
-        Type: schema.TypeBool,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_INSECURE", nil),
-        Description: "When using https, this disables TLS verification of the host.",
-      },
-      "username": &schema.Schema{
-        Type: schema.TypeString,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_USERNAME", nil),
-        Description: "When set, will use this username for BASIC auth to the API.",
-      },
-      "password": &schema.Schema{
-        Type: schema.TypeString,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_PASSWORD", nil),
-        Description: "When set, will use this password for BASIC auth to the API.",
-      },
-      "headers": &schema.Schema{
-        Type: schema.TypeMap,
-        Elem: schema.TypeString,
-        Optional: true,
-        Description: "A map of header names and values to set on all outbound requests. This is useful if you want to use a script via the 'external' provider or provide a pre-approved token or change Content-Type from `application/json`. If `username` and `password` are set and Authorization is one of the headers defined here, the BASIC auth credentials take precedence.",
-      },
-      "use_cookies": &schema.Schema{
-        Type: schema.TypeBool,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_USE_COOKIES", nil),
-        Description: "Enable cookie jar to persist session.",
-      },
-      "timeout": &schema.Schema{
-        Type: schema.TypeInt,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_TIMEOUT", 0),
-        Description: "When set, will cause requests taking longer than this time (in seconds) to be aborted.",
-      },
-      "id_attribute": &schema.Schema{
-        Type: schema.TypeString,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_ID_ATTRIBUTE", nil),
-        Description: "When set, this key will be used to operate on REST objects. For example, if the ID is set to 'name', changes to the API object will be to http://foo.com/bar/VALUE_OF_NAME. This value may also be a '/'-delimeted path to the id attribute if it is multple levels deep in the data (such as `attributes/id` in the case of an object `{ \"attributes\": { \"id\": 1234 }, \"config\": { \"name\": \"foo\", \"something\": \"bar\"}}`",
-      },
-      "copy_keys": &schema.Schema{
-        Type: schema.TypeList,
-        Elem: &schema.Schema{Type: schema.TypeString},
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_PASSWORD", nil),
-        Description: "When set, any PUT to the API for an object will copy these keys from the data the provider has gathered about the object. This is useful if internal API information must also be provided with updates, such as the revision of the object.",
-      },
-      "write_returns_object": &schema.Schema{
-        Type: schema.TypeBool,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_WRO", nil),
-        Description: "Set this when the API returns the object created on all write operations (POST, PUT). This is used by the provider to refresh internal data structures.",
-      },
-      "create_returns_object": &schema.Schema{
-        Type: schema.TypeBool,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_CRO", nil),
-        Description: "Set this when the API returns the object created only on creation operations (POST). This is used by the provider to refresh internal data structures.",
-      },
-      "xssi_prefix": &schema.Schema{
-        Type: schema.TypeString,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_XSSI_PREFIX", nil),
-        Description: "Trim the xssi prefix from response string, if present, before parsing.",
-      },
-      "debug": &schema.Schema{
-        Type: schema.TypeBool,
-        Optional: true,
-        DefaultFunc: schema.EnvDefaultFunc("REST_API_DEBUG", nil),
-        Description: "Enabling this will cause lots of debug information to be printed to STDOUT by the API client.",
-      },
-    },
-    ResourcesMap: map[string]*schema.Resource{
-      /* Could only get terraform to recognize this resource if
-         the name began with the provider's name and had at least
-	 one underscore. This is not documented anywhere I could find */
-      "restapi_object": resourceRestApi(),
-    },
-    DataSourcesMap: map[string]*schema.Resource{
-      "restapi_object": dataSourceRestApi(),
-    },
-    ConfigureFunc: configureProvider,
-  }
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"uri": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_URI", nil),
+				Description: "URI of the REST API endpoint. This serves as the base of all requests.",
+			},
+			"insecure": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_INSECURE", nil),
+				Description: "When using https, this disables TLS verification of the host.",
+			},
+			"username": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_USERNAME", nil),
+				Description: "When set, will use this username for BASIC auth to the API.",
+			},
+			"password": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_PASSWORD", nil),
+				Description: "When set, will use this password for BASIC auth to the API.",
+			},
+			"headers": &schema.Schema{
+				Type:        schema.TypeMap,
+				Elem:        schema.TypeString,
+				Optional:    true,
+				Description: "A map of header names and values to set on all outbound requests. This is useful if you want to use a script via the 'external' provider or provide a pre-approved token or change Content-Type from `application/json`. If `username` and `password` are set and Authorization is one of the headers defined here, the BASIC auth credentials take precedence.",
+			},
+			"use_cookies": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_USE_COOKIES", nil),
+				Description: "Enable cookie jar to persist session.",
+			},
+			"timeout": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_TIMEOUT", 0),
+				Description: "When set, will cause requests taking longer than this time (in seconds) to be aborted.",
+			},
+			"id_attribute": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_ID_ATTRIBUTE", nil),
+				Description: "When set, this key will be used to operate on REST objects. For example, if the ID is set to 'name', changes to the API object will be to http://foo.com/bar/VALUE_OF_NAME. This value may also be a '/'-delimeted path to the id attribute if it is multple levels deep in the data (such as `attributes/id` in the case of an object `{ \"attributes\": { \"id\": 1234 }, \"config\": { \"name\": \"foo\", \"something\": \"bar\"}}`",
+			},
+			"copy_keys": &schema.Schema{
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_PASSWORD", nil),
+				Description: "When set, any PUT to the API for an object will copy these keys from the data the provider has gathered about the object. This is useful if internal API information must also be provided with updates, such as the revision of the object.",
+			},
+			"write_returns_object": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_WRO", nil),
+				Description: "Set this when the API returns the object created on all write operations (POST, PUT). This is used by the provider to refresh internal data structures.",
+			},
+			"create_returns_object": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_CRO", nil),
+				Description: "Set this when the API returns the object created only on creation operations (POST). This is used by the provider to refresh internal data structures.",
+			},
+			"xssi_prefix": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_XSSI_PREFIX", nil),
+				Description: "Trim the xssi prefix from response string, if present, before parsing.",
+			},
+			"debug": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("REST_API_DEBUG", nil),
+				Description: "Enabling this will cause lots of debug information to be printed to STDOUT by the API client.",
+			},
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			/* Could only get terraform to recognize this resource if
+			         the name began with the provider's name and had at least
+				 one underscore. This is not documented anywhere I could find */
+			"restapi_object": resourceRestApi(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"restapi_object": dataSourceRestApi(),
+		},
+		ConfigureFunc: configureProvider,
+	}
 }
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
 
-  /* As "data-safe" as terraform says it is, you'd think
-     it would have already coaxed this to a slice FOR me */
-  copy_keys := make([]string, 0)
-  if i_copy_keys := d.Get("copy_keys"); i_copy_keys != nil {
-    for _, v := range i_copy_keys.([]interface{}) {
-      copy_keys = append(copy_keys, v.(string))
-    }
-  }
+	/* As "data-safe" as terraform says it is, you'd think
+	   it would have already coaxed this to a slice FOR me */
+	copy_keys := make([]string, 0)
+	if i_copy_keys := d.Get("copy_keys"); i_copy_keys != nil {
+		for _, v := range i_copy_keys.([]interface{}) {
+			copy_keys = append(copy_keys, v.(string))
+		}
+	}
 
-  headers := make(map[string]string)
-  if i_headers := d.Get("headers"); i_headers != nil {
-    for k, v := range i_headers.(map[string]interface{}) {
-      headers[k] = v.(string)
-    }
-  }
+	headers := make(map[string]string)
+	if i_headers := d.Get("headers"); i_headers != nil {
+		for k, v := range i_headers.(map[string]interface{}) {
+			headers[k] = v.(string)
+		}
+	}
 
-  client, err := NewAPIClient(
-    d.Get("uri").(string),
-    d.Get("insecure").(bool),
-    d.Get("username").(string),
-    d.Get("password").(string),
-    headers,
-    d.Get("use_cookies").(bool),
-    d.Get("timeout").(int),
-    d.Get("id_attribute").(string),
-    copy_keys,
-    d.Get("write_returns_object").(bool),
-    d.Get("create_returns_object").(bool),
-    d.Get("xssi_prefix").(string),
-    d.Get("debug").(bool),
-  )
-  return client, err
+	client, err := NewAPIClient(
+		d.Get("uri").(string),
+		d.Get("insecure").(bool),
+		d.Get("username").(string),
+		d.Get("password").(string),
+		headers,
+		d.Get("use_cookies").(bool),
+		d.Get("timeout").(int),
+		d.Get("id_attribute").(string),
+		copy_keys,
+		d.Get("write_returns_object").(bool),
+		d.Get("create_returns_object").(bool),
+		d.Get("xssi_prefix").(string),
+		d.Get("debug").(bool),
+	)
+	return client, err
 }

--- a/restapi/provider.go
+++ b/restapi/provider.go
@@ -119,20 +119,22 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
-	client, err := NewAPIClient(
-		d.Get("uri").(string),
-		d.Get("insecure").(bool),
-		d.Get("username").(string),
-		d.Get("password").(string),
-		headers,
-		d.Get("use_cookies").(bool),
-		d.Get("timeout").(int),
-		d.Get("id_attribute").(string),
-		copy_keys,
-		d.Get("write_returns_object").(bool),
-		d.Get("create_returns_object").(bool),
-		d.Get("xssi_prefix").(string),
-		d.Get("debug").(bool),
-	)
+	opt := &apiClientOpt{
+		uri:                   d.Get("uri").(string),
+		insecure:              d.Get("insecure").(bool),
+		username:              d.Get("username").(string),
+		password:              d.Get("password").(string),
+		headers:               headers,
+		use_cookie:            d.Get("use_cookies").(bool),
+		timeout:               d.Get("timeout").(int),
+		id_attribute:          d.Get("id_attribute").(string),
+		copy_keys:             copy_keys,
+		write_returns_object:  d.Get("write_returns_object").(bool),
+		create_returns_object: d.Get("create_returns_object").(bool),
+		xssi_prefix:           d.Get("xssi_prefix").(string),
+		debug:                 d.Get("debug").(bool),
+	}
+
+	client, err := NewAPIClient(opt)
 	return client, err
 }

--- a/restapi/provider_test.go
+++ b/restapi/provider_test.go
@@ -1,50 +1,50 @@
 package restapi
 
 import (
-  "testing"
+	"testing"
 
-  "github.com/hashicorp/terraform/config"
-  "github.com/hashicorp/terraform/helper/schema"
-  "github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 var testAccProvider terraform.ResourceProvider
 var testAccProviders map[string]terraform.ResourceProvider
 
 func init() {
-  testAccProvider = Provider().(terraform.ResourceProvider)
-  testAccProviders = map[string]terraform.ResourceProvider{
-    "restapi": testAccProvider,
-  }
+	testAccProvider = Provider().(terraform.ResourceProvider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"restapi": testAccProvider,
+	}
 }
 
 func TestProvider(t *testing.T) {
-  if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
-    t.Fatalf("err: %s", err)
-  }
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestProvider_impl(t *testing.T) {
-  var _ terraform.ResourceProvider = Provider()
+	var _ terraform.ResourceProvider = Provider()
 }
 
 func TestResourceProvider_RequireBasic(t *testing.T) {
-  rp := Provider()
+	rp := Provider()
 
-  raw := map[string]interface{}{}
+	raw := map[string]interface{}{}
 
-  rawConfig, err := config.NewRawConfig(raw)
-  if err != nil {
-    t.Fatalf("err: %s", err)
-  }
+	rawConfig, err := config.NewRawConfig(raw)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-  /*
-    XXX: This is expected to work even though we are not
-         explicitly declaring the required url paramter since
-         the test suite is run with the ENV entry set.
-  */
-  err = rp.Configure(terraform.NewResourceConfig(rawConfig))
-  if err != nil {
-    t.Fatalf("Provider failed with error: %s", err)
-  }
+	/*
+	   XXX: This is expected to work even though we are not
+	        explicitly declaring the required url paramter since
+	        the test suite is run with the ENV entry set.
+	*/
+	err = rp.Configure(terraform.NewResourceConfig(rawConfig))
+	if err != nil {
+		t.Fatalf("Provider failed with error: %s", err)
+	}
 }

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -1,201 +1,215 @@
 package restapi
 
 import (
-  "github.com/hashicorp/terraform/helper/schema"
-  "fmt"
-  "strings"
-  "log"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
 )
 
 func resourceRestApi() *schema.Resource {
-  return &schema.Resource{
-    Create: resourceRestApiCreate,
-    Read:   resourceRestApiRead,
-    Update: resourceRestApiUpdate,
-    Delete: resourceRestApiDelete,
-    Exists: resourceRestApiExists,
+	return &schema.Resource{
+		Create: resourceRestApiCreate,
+		Read:   resourceRestApiRead,
+		Update: resourceRestApiUpdate,
+		Delete: resourceRestApiDelete,
+		Exists: resourceRestApiExists,
 
-    Importer: &schema.ResourceImporter{
-      State: resourceRestApiImport,
-    },
+		Importer: &schema.ResourceImporter{
+			State: resourceRestApiImport,
+		},
 
+		Schema: map[string]*schema.Schema{
+			"path": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The API path on top of the base URL set in the provider that represents objects of this type on the API server.",
+				Required:    true,
+			},
+			"create_path": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Defaults to `path`. The API path that represents where to CREATE (POST) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object if the data contains the `id_attribute`.",
+				Optional:    true,
+			},
+			"read_path": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Defaults to `path/{id}`. The API path that represents where to READ (GET) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.",
+				Optional:    true,
+			},
+			"update_path": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Defaults to `path/{id}`. The API path that represents where to UPDATE (PUT) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.",
+				Optional:    true,
+			},
+			"destroy_path": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Defaults to `path/{id}`. The API path that represents where to DESTROY (DELETE) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.",
+				Optional:    true,
+			},
+			"id_attribute": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)",
+				Optional:    true,
+			},
+			"object_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Defaults to the id learned by the provider during normal operations and `id_attribute`. Allows you to set the id manually. This is used in conjunction with the `*_path` attributes.",
+				Optional:    true,
+			},
+			"data": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Valid JSON data that this provider will manage with the API server.",
+				Required:    true,
+			},
+			"debug": &schema.Schema{
+				Type:        schema.TypeBool,
+				Description: "Whether to emit verbose debug output while working with the API object on the server.",
+				Optional:    true,
+			},
+			"api_data": &schema.Schema{
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "After data from the API server is read, this map will include k/v pairs usable in other terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).",
+				Computed:    true,
+			},
+			"force_new": &schema.Schema{
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Any changes to these values will result in recreating the resource instead of updating.",
+			},
+		}, /* End schema */
 
-    Schema: map[string]*schema.Schema{
-      "path": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "The API path on top of the base URL set in the provider that represents objects of this type on the API server.",
-        Required:    true,
-      },
-      "create_path": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "Defaults to `path`. The API path that represents where to CREATE (POST) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object if the data contains the `id_attribute`.",
-        Optional:    true,
-      },
-      "read_path": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "Defaults to `path/{id}`. The API path that represents where to READ (GET) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.",
-        Optional:    true,
-      },
-      "update_path": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "Defaults to `path/{id}`. The API path that represents where to UPDATE (PUT) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.",
-        Optional:    true,
-      },
-      "destroy_path": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "Defaults to `path/{id}`. The API path that represents where to DESTROY (DELETE) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.",
-        Optional:    true,
-      },
-      "id_attribute": &schema.Schema{
-        Type: schema.TypeString,
-        Description: "Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)",
-        Optional: true,
-      },
-      "object_id": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "Defaults to the id learned by the provider during normal operations and `id_attribute`. Allows you to set the id manually. This is used in conjunction with the `*_path` attributes.",
-        Optional:    true,
-      },
-      "data": &schema.Schema{
-        Type:        schema.TypeString,
-        Description: "Valid JSON data that this provider will manage with the API server.",
-        Required:    true,
-      },
-      "debug": &schema.Schema{
-        Type:        schema.TypeBool,
-        Description: "Whether to emit verbose debug output while working with the API object on the server.",
-        Optional:    true,
-      },
-      "api_data": &schema.Schema{
-        Type:        schema.TypeMap,
-	Elem:        &schema.Schema{ Type: schema.TypeString },
-        Description: "After data from the API server is read, this map will include k/v pairs usable in other terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).",
-	Computed:    true,
-      },
-      "force_new": &schema.Schema{
-        Type: schema.TypeList,
-        Elem: &schema.Schema{Type: schema.TypeString},
-        Optional: true,
-        ForceNew: true,
-        Description: "Any changes to these values will result in recreating the resource instead of updating.",
-      },
-    }, /* End schema */
-
-  }
+	}
 }
-
 
 /* Since there is nothing in the ResourceData structure other
    than the "id" passed on the command line, we have to use an opinionated
    view of the API paths to figure out how to read that object
    from the API */
 func resourceRestApiImport(d *schema.ResourceData, meta interface{}) (imported []*schema.ResourceData, err error) {
-  input := d.Id()
-  n := strings.LastIndex(input, "/")
-  if n == -1 { return imported, fmt.Errorf("Invalid path to import api_object '%s'. Must be /<full path from server root>/<object id>", input) }
+	input := d.Id()
+	n := strings.LastIndex(input, "/")
+	if n == -1 {
+		return imported, fmt.Errorf("Invalid path to import api_object '%s'. Must be /<full path from server root>/<object id>", input)
+	}
 
-  path := input[0:n]
-  d.Set("path", path)
+	path := input[0:n]
+	d.Set("path", path)
 
-  id := input[n+1:len(input)]
-  d.Set("data", fmt.Sprintf(`{ "id": "%s" }`, id))
-  d.SetId(id)
+	id := input[n+1 : len(input)]
+	d.Set("data", fmt.Sprintf(`{ "id": "%s" }`, id))
+	d.SetId(id)
 
-  /* Troubleshooting is hard enough. Emit log messages so TF_LOG
-     has useful information in case an import isn't working */
-  d.Set("debug", true)
+	/* Troubleshooting is hard enough. Emit log messages so TF_LOG
+	   has useful information in case an import isn't working */
+	d.Set("debug", true)
 
-  obj, err := make_api_object(d, meta)
-  if err != nil { return imported, err }
-  log.Printf("resource_api_object.go: Import routine called. Object built:\n%s\n", obj.toString())
+	obj, err := make_api_object(d, meta)
+	if err != nil {
+		return imported, err
+	}
+	log.Printf("resource_api_object.go: Import routine called. Object built:\n%s\n", obj.toString())
 
-  err = obj.read_object()
-  if err == nil {
-    set_resource_state(obj, d)
-    /* Data that we set in the state above must be passed along
-       as an item in the stack of imported data */
-    imported = append(imported, d)
-  }
+	err = obj.read_object()
+	if err == nil {
+		set_resource_state(obj, d)
+		/* Data that we set in the state above must be passed along
+		   as an item in the stack of imported data */
+		imported = append(imported, d)
+	}
 
-  return imported, err
+	return imported, err
 }
 
 func resourceRestApiCreate(d *schema.ResourceData, meta interface{}) error {
-  obj, err := make_api_object(d, meta)
-  if err != nil { return err }
-  log.Printf("resource_api_object.go: Create routine called. Object built:\n%s\n", obj.toString())
+	obj, err := make_api_object(d, meta)
+	if err != nil {
+		return err
+	}
+	log.Printf("resource_api_object.go: Create routine called. Object built:\n%s\n", obj.toString())
 
-  err = obj.create_object()
-  if err == nil {
-    /* Setting terraform ID tells terraform the object was created or it exists */
-    d.SetId(obj.id)
-    set_resource_state(obj, d)
-  }
-  return err
+	err = obj.create_object()
+	if err == nil {
+		/* Setting terraform ID tells terraform the object was created or it exists */
+		d.SetId(obj.id)
+		set_resource_state(obj, d)
+	}
+	return err
 }
 
 func resourceRestApiRead(d *schema.ResourceData, meta interface{}) error {
-  obj, err := make_api_object(d, meta)
-  if err != nil { return err }
-  log.Printf("resource_api_object.go: Read routine called. Object built:\n%s\n", obj.toString())
+	obj, err := make_api_object(d, meta)
+	if err != nil {
+		return err
+	}
+	log.Printf("resource_api_object.go: Read routine called. Object built:\n%s\n", obj.toString())
 
-  err = obj.read_object()
-  if err == nil {
-    /* Setting terraform ID tells terraform the object was created or it exists */
-    log.Printf("resource_api_object.go: Read resource. Returned id is '%s'\n", obj.id);
-    d.SetId(obj.id)
-    set_resource_state(obj, d)
-  }
-  return err
+	err = obj.read_object()
+	if err == nil {
+		/* Setting terraform ID tells terraform the object was created or it exists */
+		log.Printf("resource_api_object.go: Read resource. Returned id is '%s'\n", obj.id)
+		d.SetId(obj.id)
+		set_resource_state(obj, d)
+	}
+	return err
 }
 
 func resourceRestApiUpdate(d *schema.ResourceData, meta interface{}) error {
-  obj, err := make_api_object(d, meta)
-  if err != nil { return err }
+	obj, err := make_api_object(d, meta)
+	if err != nil {
+		return err
+	}
 
-  /* If copy_keys is not empty, we have to grab the latest 
-     data so we can copy anything needed before the update */
-  client := meta.(*api_client)
-  if len(client.copy_keys) > 0 {
-    err = obj.read_object()
-    if err != nil { return err }
-  }
+	/* If copy_keys is not empty, we have to grab the latest
+	   data so we can copy anything needed before the update */
+	client := meta.(*api_client)
+	if len(client.copy_keys) > 0 {
+		err = obj.read_object()
+		if err != nil {
+			return err
+		}
+	}
 
-  log.Printf("resource_api_object.go: Update routine called. Object built:\n%s\n", obj.toString())
+	log.Printf("resource_api_object.go: Update routine called. Object built:\n%s\n", obj.toString())
 
-  err = obj.update_object()
-  if err == nil {
-    set_resource_state(obj, d)
-  }
-  return err
+	err = obj.update_object()
+	if err == nil {
+		set_resource_state(obj, d)
+	}
+	return err
 }
 
 func resourceRestApiDelete(d *schema.ResourceData, meta interface{}) error {
-  obj, err := make_api_object(d, meta)
-  if err != nil { return err }
-  log.Printf("resource_api_object.go: Delete routine called. Object built:\n%s\n", obj.toString())
+	obj, err := make_api_object(d, meta)
+	if err != nil {
+		return err
+	}
+	log.Printf("resource_api_object.go: Delete routine called. Object built:\n%s\n", obj.toString())
 
-  err = obj.delete_object()
-  if err != nil {
-    if strings.Contains(err.Error(), "404") {
-      /* 404 means it doesn't exist. Call that good enough */
-      err = nil
-    }
-  }
-  return err
+	err = obj.delete_object()
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			/* 404 means it doesn't exist. Call that good enough */
+			err = nil
+		}
+	}
+	return err
 }
 
 func resourceRestApiExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {
-  exists := false
-  obj, err := make_api_object(d, meta)
-  if err != nil { return false, err }
-  log.Printf("resource_api_object.go: Exists routine called. Object built: %s\n", obj.toString())
+	exists := false
+	obj, err := make_api_object(d, meta)
+	if err != nil {
+		return false, err
+	}
+	log.Printf("resource_api_object.go: Exists routine called. Object built: %s\n", obj.toString())
 
-  err = obj.read_object()
-  /* Assume all errors indicate the object just doesn't exist.
-     This may not be a good assumption... */
-  if err == nil {
-    exists = true
-  }
-  return exists, nil
+	err = obj.read_object()
+	/* Assume all errors indicate the object just doesn't exist.
+	   This may not be a good assumption... */
+	if err == nil {
+		exists = true
+	}
+	return exists, nil
 }

--- a/restapi/resource_api_object_test.go
+++ b/restapi/resource_api_object_test.go
@@ -13,87 +13,89 @@ package restapi
   "fmt"
 */
 import (
-  "os"
-  "testing"
-  "encoding/json"
-  "github.com/hashicorp/terraform/helper/resource"
-  "github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"encoding/json"
+	"github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+	"testing"
 )
 
 // example.Widget represents a concrete Go type that represents an API resource
 func TestAccRestApiObject_Basic(t *testing.T) {
-  debug := false
-  api_server_objects := make(map[string]map[string]interface{})
+	debug := false
+	api_server_objects := make(map[string]map[string]interface{})
 
-  svr := fakeserver.NewFakeServer(8082, api_server_objects, true, debug, "")
-  os.Setenv("REST_API_URI", "http://127.0.0.1:8082")
+	svr := fakeserver.NewFakeServer(8082, api_server_objects, true, debug, "")
+	os.Setenv("REST_API_URI", "http://127.0.0.1:8082")
 
-  client, err := NewAPIClient("http://127.0.0.1:8082/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
-  if err != nil { t.Fatal(err) }
+	client, err := NewAPIClient("http://127.0.0.1:8082/", false, "", "", make(map[string]string, 0), 2, "id", make([]string, 0), false, false, debug)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-  resource.UnitTest(t, resource.TestCase{
-    Providers:    testAccProviders,
-    PreCheck:     func() { svr.StartInBackground() },
-    Steps: []resource.TestStep{
-      {
-        Config: generate_test_resource(
-          "Foo",
-          `{ "id": "1234", "first": "Foo", "last": "Bar" }`,
-          make(map[string]interface{}),
-        ),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckRestapiObjectExists("restapi_object.Foo", "1234", client),
-          resource.TestCheckResourceAttr("restapi_object.Foo", "id", "1234"),
-          resource.TestCheckResourceAttr("restapi_object.Foo", "api_data.first", "Foo"),
-          resource.TestCheckResourceAttr("restapi_object.Foo", "api_data.last", "Bar"),
-        ),
-      },
-      /* Make a complex object with id_attribute as a child of another key
-         Note that we have to pass "id" just so fakeserver won't get angry at us
-       */
-      {
-        Config: generate_test_resource(
-          "Bar",
-          `{ "id": "4321", "attributes": { "id": "4321" }, "config": { "first": "Bar", "last": "Baz" } }`,
-          map[string]interface{}{
-            "debug": debug,
-            "id_attribute": "attributes/id",
-          },
-        ),
-        Check: resource.ComposeTestCheckFunc(
-          testAccCheckRestapiObjectExists("restapi_object.Bar", "4321", client),
-          resource.TestCheckResourceAttr("restapi_object.Bar", "id", "4321"),
-          resource.TestCheckResourceAttrSet("restapi_object.Bar", "api_data.config"),
-        ),
-      },
-    },
-  })
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { svr.StartInBackground() },
+		Steps: []resource.TestStep{
+			{
+				Config: generate_test_resource(
+					"Foo",
+					`{ "id": "1234", "first": "Foo", "last": "Bar" }`,
+					make(map[string]interface{}),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRestapiObjectExists("restapi_object.Foo", "1234", client),
+					resource.TestCheckResourceAttr("restapi_object.Foo", "id", "1234"),
+					resource.TestCheckResourceAttr("restapi_object.Foo", "api_data.first", "Foo"),
+					resource.TestCheckResourceAttr("restapi_object.Foo", "api_data.last", "Bar"),
+				),
+			},
+			/* Make a complex object with id_attribute as a child of another key
+			   Note that we have to pass "id" just so fakeserver won't get angry at us
+			*/
+			{
+				Config: generate_test_resource(
+					"Bar",
+					`{ "id": "4321", "attributes": { "id": "4321" }, "config": { "first": "Bar", "last": "Baz" } }`,
+					map[string]interface{}{
+						"debug":        debug,
+						"id_attribute": "attributes/id",
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRestapiObjectExists("restapi_object.Bar", "4321", client),
+					resource.TestCheckResourceAttr("restapi_object.Bar", "id", "4321"),
+					resource.TestCheckResourceAttrSet("restapi_object.Bar", "api_data.config"),
+				),
+			},
+		},
+	})
 
-  svr.Shutdown()
+	svr.Shutdown()
 }
 
 /* This function generates a terraform JSON configuration from
    a name, JSON data and a list of params to set by coaxing it
    all to maps and then serializing to JSON */
 func generate_test_resource(name string, data string, params map[string]interface{}) string {
-  config := map[string]interface{}{
-    "path": "/api/objects",
-    "data": data,
-  }
+	config := map[string]interface{}{
+		"path": "/api/objects",
+		"data": data,
+	}
 
-  for k, v := range params {
-    config[k] = v
-  }
+	for k, v := range params {
+		config[k] = v
+	}
 
-  //What a mess...
-  generated := map[string]interface{}{
-    "resource": map[string]interface{}{
-      "restapi_object": map[string]interface{}{
-        name: config,
-      },
-    },
-  }
+	//What a mess...
+	generated := map[string]interface{}{
+		"resource": map[string]interface{}{
+			"restapi_object": map[string]interface{}{
+				name: config,
+			},
+		},
+	}
 
-  res, _ := json.Marshal(generated)
-  return string(res)
+	res, _ := json.Marshal(generated)
+	return string(res)
 }


### PR DESCRIPTION
Since `use_cookie` param was added it wasn't passed in tests calls causing
them to fail. Replaced long param list with pointer to apiClientOpt struct.

Additionally `resource.TestCase.Config` is no longer accepted as a JSON. Replaced it
with HCL.

I based my branch off TMaYaD's 'go fmt' pull request. Didn't want to deal with non-standard formatting myself. Hope that's OK and we will see standard formatting soon?

Happy to discuss changes.