### PR TITLE
Allow 'data' field to be treated  as 'sensitive'

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This provider also exports the following parameters:
 
 Note that the `*_path` elements are for very specific use cases where one might initially create an object in one location, but read/update/delete it on another path. For this reason, they allow for substitution to be done by the provider internally by injecting the `id` somewhere along the path. This is similar to terraform's substitution syntax in the form of `${variable.name}`, but must be done within the provider due to structure. The only substitution available is to replace the string `{id}` with the internal (terraform) `id` of the object as learned by the `id_attribute`.
 
+By default data isn't considered as sensitive if you want to hide `data's` value in output you would need to set environment variable `API_DATA_IS_SENSITIVE="true"`.
 &nbsp;
 
 ## `restapi` datasource configuration

--- a/restapi/common.go
+++ b/restapi/common.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"strings"
+	"os"
 )
 
 /* After any operation that returns API data, we'll stuff
@@ -131,4 +132,14 @@ func GetKeys(hash map[string]interface{}) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+/* GetEnvOrDefault is a helper function that returns the value of the
+given environment variable, if one exists, or the default value */
+func GetEnvOrDefault (k string, defaultvalue string) string{
+        v := os.Getenv(k)
+        if v == "" {
+            return defaultvalue
+        }
+        return v
 }

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -5,9 +5,15 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"strings"
+	"strconv"
 )
 
+
+
 func resourceRestApi() *schema.Resource {
+	// Consider data sensitive if env variables is set to true.
+	is_data_sensitive, _ := strconv.ParseBool(GetEnvOrDefault("API_DATA_IS_SENSITIVE", "false"))
+
 	return &schema.Resource{
 		Create: resourceRestApiCreate,
 		Read:   resourceRestApiRead,
@@ -59,6 +65,7 @@ func resourceRestApi() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Valid JSON data that this provider will manage with the API server.",
 				Required:    true,
+				Sensitive:   is_data_sensitive,
 			},
 			"debug": &schema.Schema{
 				Type:        schema.TypeBool,

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 )
 
-
-
 func resourceRestApi() *schema.Resource {
 	// Consider data sensitive if env variables is set to true.
 	is_data_sensitive, _ := strconv.ParseBool(GetEnvOrDefault("API_DATA_IS_SENSITIVE", "false"))


### PR DESCRIPTION
I want  plugin not to show sensitive data in  output. Unfortunately, it looks impossible to hide some specific fields in output - only whole 'data' entry could be hidden.
