### PR TITLE
Abort on 500 Internal Server Errors

### DIFF
--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
@@ -217,10 +218,6 @@ func resourceRestApiExists(d *schema.ResourceData, meta interface{}) (exists boo
 	if err := obj.read_object(); err == nil {
 		exists = true
 	}
-        if err != nil {
-            if strings.Contains(err.Error(), "500") {
-                /* 500 Internal Server error is indicative of a API server error */
-
 	return exists, err
 }
 

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -204,6 +204,10 @@ func resourceRestApiDelete(d *schema.ResourceData, meta interface{}) error {
 func resourceRestApiExists(d *schema.ResourceData, meta interface{}) (exists bool, err error) {
 	obj, err := make_api_object(d, meta)
 	if err != nil {
+            /* 500 Internal Server error is indicative of a API server error */
+            if string.Contains(err.Error(), "500") {
+                panic(errors.New("API responded with a 500 Internal Server Error"))
+            }
 		return exists, err
 	}
 	log.Printf("resource_api_object.go: Exists routine called. Object built: %s\n", obj.toString())
@@ -213,6 +217,10 @@ func resourceRestApiExists(d *schema.ResourceData, meta interface{}) (exists boo
 	if err := obj.read_object(); err == nil {
 		exists = true
 	}
+        if err != nil {
+            if strings.Contains(err.Error(), "500") {
+                /* 500 Internal Server error is indicative of a API server error */
+
 	return exists, err
 }
 


### PR DESCRIPTION
The code doesn't contain retry functionality so on a simple 500 Internal Server error we should handle this as an uncaught exception and die. 

Ideally we have classes of retry-able errors and unrecoverable errors... but we probably shouldn't invalidate resources as it seems like a bad claim to make. 