### PR TITLE
Retry on errors with specified HTTP methods

### DIFF
--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -264,7 +264,7 @@ func (client *api_client) send_request(method string, path string, data string) 
 		if resp.StatusCode == 301 || resp.StatusCode == 302 {
 			//Redirecting... decrement num_retries and proceed to the next loop
 			//uri = URI.parse(rsp['Location'])
-		} else if num_retries != 0 && (resp.StatusCode >= 500 || resp.StatusCode < 600) {
+		} else if num_retries != 0 && resp.StatusCode >= 500 && resp.StatusCode < 600 {
 			if client.debug {
 				log.Printf("Received response code '%d': %s - Retrying", resp.StatusCode, body)
 			}
@@ -279,5 +279,5 @@ func (client *api_client) send_request(method string, path string, data string) 
 		num_retries--
 	} //End loop through retry attempts
 
-	return "", errors.New("Error - too many redirects!")
+	return "", errors.New("Error - too many retries!")
 }

--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -157,7 +157,7 @@ func (obj *api_client) toString() string {
 	return buffer.String()
 }
 
-/* helper function for retry_methods condition */
+/* Helper function for retry_methods condition */
 func sliceContains(a string, list []string) bool {
 	for _, b := range list {
 		if b == a {
@@ -229,6 +229,7 @@ func (client *api_client) send_request(method string, path string, data string) 
 		log.Printf("%s\n", body)
 	}
 
+	/* Retry only if this is one of the user specified HTTP methods to retry on */
 	num_retries := 0
 	if len(client.retry_methods) > 0 && sliceContains(method, client.retry_methods) {
 		num_retries = 5
@@ -276,7 +277,7 @@ func (client *api_client) send_request(method string, path string, data string) 
 			return body, nil
 		}
 		num_retries--
-	} //End loop through redirect attempts
+	} //End loop through retry attempts
 
 	return "", errors.New("Error - too many redirects!")
 }

--- a/restapi/provider.go
+++ b/restapi/provider.go
@@ -76,6 +76,12 @@ func Provider() terraform.ResourceProvider {
 				Description: "Defaults to `DELETE`. The HTTP method used to DELETE objects of this type on the API server.",
 				Optional:    true,
 			},
+			"retry_methods": &schema.Schema{
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "Defines a list of HTTP methods to retry when retry_errors is set. Defaults to an empty list (no retries)",
+			},
 			"copy_keys": &schema.Schema{
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -139,6 +145,13 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
+	retry_methods := make([]string, 0)
+	if i_retry_methods := d.Get("retry_methods"); i_retry_methods != nil {
+		for _, v := range i_retry_methods.([]interface{}) {
+			retry_methods = append(retry_methods, v.(string))
+		}
+	}
+
 	opt := &apiClientOpt{
 		uri:                   d.Get("uri").(string),
 		insecure:              d.Get("insecure").(bool),
@@ -153,6 +166,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		create_returns_object: d.Get("create_returns_object").(bool),
 		xssi_prefix:           d.Get("xssi_prefix").(string),
 		debug:                 d.Get("debug").(bool),
+		retry_methods:         retry_methods,
 	}
 
 	if v, ok := d.GetOk("create_method"); ok {

--- a/restapi/provider.go
+++ b/restapi/provider.go
@@ -80,7 +80,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
-				Description: "Defines a list of HTTP methods to retry when retry_errors is set. Defaults to an empty list (no retries)",
+				Description: "Defines a list of HTTP methods to retry on when receiving a HTTP response code in the 500 range. Defaults to an empty list (no retries)",
 			},
 			"copy_keys": &schema.Schema{
 				Type:        schema.TypeList,


### PR DESCRIPTION
Supersedes PR: https://github.com/Mastercard/terraform-provider-restapi/pull/36
Issue: https://github.com/Mastercard/terraform-provider-restapi/issues/34

Allow the user to specify a list of HTTP methods to retry requests on if a status code in the range [500, 600] is received. 