### PR TITLE
Add `api_response`/`create_response` attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Have a look at the [examples directory](examples) for some use cases
 
 This provider also exports the following parameters:
 - `id`: The ID of the object that is being managed.
-- `api_data`: After data from the API server is read, this map will include k/v pairs usable in other terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).
+- `api_data`: After data from the API server is read, this map will include k/v pairs usable in other Terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).
+- `api_response`: Contains the raw JSON response read back from the API server. Can be parsed with [`jsondecode`](https://www.terraform.io/docs/configuration/functions/jsondecode.html) to allow access to deeply nested data.
+- `create_response`: Contains the raw JSON response from the initial object creation - use when an API only returns required data during create. Can be parsed with [`jsondecode`](https://www.terraform.io/docs/configuration/functions/jsondecode.html) to allow access to deeply nested data.
 
 Note that the `*_path` elements are for very specific use cases where one might initially create an object in one location, but read/update/delete it on another path. For this reason, they allow for substitution to be done by the provider internally by injecting the `id` somewhere along the path. This is similar to terraform's substitution syntax in the form of `${variable.name}`, but must be done within the provider due to structure. The only substitution available is to replace the string `{id}` with the internal (terraform) `id` of the object as learned by the `id_attribute`.
 

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"log"
 	"reflect"
 	"strings"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 type apiObjectOpts struct {
@@ -36,8 +37,9 @@ type api_object struct {
 	id_attribute string
 
 	/* Set internally */
-	data     map[string]interface{} /* Data as managed by the user */
-	api_data map[string]interface{} /* Data as available from the API */
+	data         map[string]interface{} /* Data as managed by the user */
+	api_data     map[string]interface{} /* Data as available from the API */
+	api_response string
 }
 
 // Make an api_object to manage a RESTful object in an API
@@ -151,6 +153,9 @@ func (obj *api_object) update_state(state string) error {
 	if err != nil {
 		return err
 	}
+
+	/* Store response body for parsing via jsondecode() */
+	obj.api_response = state
 
 	/* A usable ID was not passed (in constructor or here),
 	   so we have to guess what it is from the data structure */

--- a/restapi/common.go
+++ b/restapi/common.go
@@ -2,11 +2,12 @@ package restapi
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 /* After any operation that returns API data, we'll stuff
@@ -18,6 +19,7 @@ func set_resource_state(obj *api_object, d *schema.ResourceData) {
 		api_data[k] = fmt.Sprintf("%v", v)
 	}
 	d.Set("api_data", api_data)
+	d.Set("api_response", obj.api_response)
 }
 
 /* Using GetObjectAtKey, this function verifies the resulting
@@ -33,7 +35,7 @@ func GetStringAtKey(data map[string]interface{}, path string, debug bool) (strin
 	if t == "string" {
 		return res.(string), nil
 	} else if t == "float64" {
-                return strconv.FormatFloat(res.(float64), 'f', -1, 64), nil
+		return strconv.FormatFloat(res.(float64), 'f', -1, 64), nil
 	} else {
 		return "", fmt.Errorf("Object at path '%s' is not a JSON string or number (float64). The go fmt package says it is '%T'", path, res)
 	}

--- a/restapi/import_api_object_test.go
+++ b/restapi/import_api_object_test.go
@@ -1,10 +1,11 @@
 package restapi
 
 import (
-	"github.com/Mastercard/terraform-provider-restapi/fakeserver"
-	"github.com/hashicorp/terraform/helper/resource"
 	"os"
 	"testing"
+
+	"github.com/Mastercard/terraform-provider-restapi/fakeserver"
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccRestApiObject_importBasic(t *testing.T) {
@@ -25,7 +26,7 @@ func TestAccRestApiObject_importBasic(t *testing.T) {
 		copy_keys:             make([]string, 0),
 		write_returns_object:  false,
 		create_returns_object: false,
-		debug: debug,
+		debug:                 debug,
 	}
 	client, err := NewAPIClient(opt)
 	if err != nil {
@@ -45,12 +46,13 @@ func TestAccRestApiObject_importBasic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "restapi_object.Foo",
-				ImportState:             true,
-				ImportStateId:           "1234",
-				ImportStateIdPrefix:     "/api/objects/",
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"debug", "data"},
+				ResourceName:        "restapi_object.Foo",
+				ImportState:         true,
+				ImportStateId:       "1234",
+				ImportStateIdPrefix: "/api/objects/",
+				ImportStateVerify:   true,
+				/* create_response isn't populated during import (we don't know the API response from creation) */
+				ImportStateVerifyIgnore: []string{"debug", "data", "create_response"},
 			},
 		},
 	})

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -2,10 +2,11 @@ package restapi
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceRestApi() *schema.Resource {
@@ -76,6 +77,16 @@ func resourceRestApi() *schema.Resource {
 				Description: "After data from the API server is read, this map will include k/v pairs usable in other terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).",
 				Computed:    true,
 			},
+			"api_response": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The raw body of the HTTP response from the last read of the object.",
+				Computed:    true,
+			},
+			"create_response": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The raw body of the HTTP response returned when creating the object.",
+				Computed:    true,
+			},
 			"force_new": &schema.Schema{
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -139,6 +150,8 @@ func resourceRestApiCreate(d *schema.ResourceData, meta interface{}) error {
 		/* Setting terraform ID tells terraform the object was created or it exists */
 		d.SetId(obj.id)
 		set_resource_state(obj, d)
+		/* Only set during create for APIs that don't return sensitive data on subsequent retrieval */
+		d.Set("create_response", obj.api_response)
 	}
 	return err
 }


### PR DESCRIPTION
This PR adds the following attributes:

- `api_response`: Contains the raw JSON response read back from the API server. Can be parsed with [`jsondecode`](https://www.terraform.io/docs/configuration/functions/jsondecode.html) to allow access to deeply nested data.
- `create_response`: Contains the raw JSON response from the initial object creation - use when an API only returns required data during create. Can be parsed with [`jsondecode`](https://www.terraform.io/docs/configuration/functions/jsondecode.html) to allow access to deeply nested data.

I'm using this provider with the Opsgenie API to setup new integrations with AWS CloudWatch. These changes address the following use cases:

* When I create an integration it returns an API key during the `POST` request, but it's not returned in `GET` requests after that. Adding `create_response` in association with `create_returns_object`/`write_returns_object` allows me to use the `apiKey` attribute returned to set up an SNS notification subscription