### PR TITLE
Fix issue that breaks inside alpine based docker image

### DIFF
--- a/scripts/do_release.sh
+++ b/scripts/do_release.sh
@@ -4,7 +4,7 @@ OSs=("darwin" "linux" "windows")
 ARCHs=("386" "amd64")
 
 export REST_API_URI="http://127.0.0.1:8082"
-export GOPATH="$HOME/go"
+[[ -z "${GOPATH}" ]] && export GOPATH=$HOME/go
 export CGO_ENABLED=0
 
 #Get into the right directory

--- a/scripts/do_release.sh
+++ b/scripts/do_release.sh
@@ -5,6 +5,7 @@ ARCHs=("386" "amd64")
 
 export REST_API_URI="http://127.0.0.1:8082"
 export GOPATH="$HOME/go"
+export CGO_ENABLED=0
 
 #Get into the right directory
 cd $(dirname $0)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,7 +4,8 @@ cd $(dirname $0)
 
 export GOOS=""
 export GOARCH=""
-export GOPATH="$HOME/go"
+
+[[ -z "${GOPATH}" ]] && export GOPATH=$HOME/go
 
 echo "Synchronizing dependencies..."
 cd ../


### PR DESCRIPTION
This PR is to fix the issue #65.

I have tested in my local, by setting `CGO_ENABLED=0` the built artifact can be used in an alpine based docker image.