### PR TITLE
http.Transport now respects proxy settings from environment variables

### DIFF
--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -92,6 +92,7 @@ func NewAPIClient(opt *apiClientOpt) (*api_client, error) {
 	/* Disable TLS verification if requested */
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: opt.insecure},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	var cookieJar http.CookieJar


### PR DESCRIPTION
This PR is to fix #63 and #62.

I had the same issue that this provider does not use the HTTP_PROXY and HTTPS_PROXY environment variables configured on my system.

This PR should fix this behavior.