### PR TITLE
Bugfix: import with trailing slash

### DIFF
--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -106,10 +106,10 @@ func resourceRestApi() *schema.Resource {
 func resourceRestApiImport(d *schema.ResourceData, meta interface{}) (imported []*schema.ResourceData, err error) {
 	input := d.Id()
 
-	hasTrailingSlash := strings.LastIndex(input, "/") == len(input)
+	hasTrailingSlash := strings.LastIndex(input, "/") == len(input)-1
 	var n int
 	if (hasTrailingSlash) {
-		n = strings.LastIndex(input[0:len(input)-1], "/")
+		n = strings.LastIndex(input[0 : len(input) - 1], "/")
 	} else {
 		n = strings.LastIndex(input, "/")
 	}
@@ -123,9 +123,9 @@ func resourceRestApiImport(d *schema.ResourceData, meta interface{}) (imported [
 
 	var id string
 	if (hasTrailingSlash) {
-		id = input[n+1 : len(input)-1]
+		id = input[n + 1 : len(input) - 1]
 	} else {
-		id = input[n+1 : len(input)]
+		id = input[n + 1 : len(input)]
 	}
 
 	d.Set("data", fmt.Sprintf(`{ "id": "%s" }`, id))

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -105,7 +105,15 @@ func resourceRestApi() *schema.Resource {
    from the API */
 func resourceRestApiImport(d *schema.ResourceData, meta interface{}) (imported []*schema.ResourceData, err error) {
 	input := d.Id()
-	n := strings.LastIndex(input, "/")
+
+	hasTrailingSlash := strings.LastIndex(input, "/") == len(input)
+	var n int
+	if (hasTrailingSlash) {
+		n = strings.LastIndex(input[0:len(input)-1], "/")
+	} else {
+		n = strings.LastIndex(input, "/")
+	}
+
 	if n == -1 {
 		return imported, fmt.Errorf("Invalid path to import api_object '%s'. Must be /<full path from server root>/<object id>", input)
 	}
@@ -113,7 +121,13 @@ func resourceRestApiImport(d *schema.ResourceData, meta interface{}) (imported [
 	path := input[0:n]
 	d.Set("path", path)
 
-	id := input[n+1 : len(input)]
+	var id string
+	if (hasTrailingSlash) {
+		id = input[n+1 : len(input)-1]
+	} else {
+		id = input[n+1 : len(input)]
+	}
+
 	d.Set("data", fmt.Sprintf(`{ "id": "%s" }`, id))
 	d.SetId(id)
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -17,7 +17,7 @@
 			"revisionTime": "2019-04-12T11:37:27Z"
 		},
 		{
-			"checksumSHA1": "l/n8xKSFhL5eWDsVE52JwUDl78A=",
+			"checksumSHA1": "Ffhtm8iHH7l2ynVVOIGJE3eiuLA=",
 			"origin": "github.com/hashicorp/terraform/vendor/github.com/apparentlymart/go-textseg/textseg",
 			"path": "github.com/apparentlymart/go-textseg/textseg",
 			"revision": "1c95b21c6cfffc50cb6b3c3c23b2257d28b61a9c",
@@ -534,7 +534,7 @@
 			"revisionTime": "2019-04-12T11:37:27Z"
 		},
 		{
-			"checksumSHA1": "teZHH2MsmI96MNuuP9ieTnes4J8=",
+			"checksumSHA1": "2ydZqQU4ao+N/unf12jVRCimKsQ=",
 			"origin": "github.com/hashicorp/terraform/vendor/github.com/hashicorp/hcl2/hcl/hclsyntax",
 			"path": "github.com/hashicorp/hcl2/hcl/hclsyntax",
 			"revision": "1c95b21c6cfffc50cb6b3c3c23b2257d28b61a9c",
@@ -1034,7 +1034,7 @@
 			"revisionTime": "2019-04-12T11:37:27Z"
 		},
 		{
-			"checksumSHA1": "IK8Sgkc7FuI8iTjDZ63Jh+ZS66Y=",
+			"checksumSHA1": "yeqdMHNrpUPwTUF7cKQ8B7SBT1w=",
 			"origin": "github.com/hashicorp/terraform/vendor/github.com/ulikunitz/xz",
 			"path": "github.com/ulikunitz/xz",
 			"revision": "1c95b21c6cfffc50cb6b3c3c23b2257d28b61a9c",
@@ -1244,7 +1244,7 @@
 			"revisionTime": "2019-04-12T11:37:27Z"
 		},
 		{
-			"checksumSHA1": "sEnY0M5iGRsoXHsjHqFVLPc+OQs=",
+			"checksumSHA1": "3IuYjR6Fs39lJcU4N9KJFvjJx2I=",
 			"origin": "github.com/hashicorp/terraform/vendor/golang.org/x/sys/unix",
 			"path": "golang.org/x/sys/unix",
 			"revision": "1c95b21c6cfffc50cb6b3c3c23b2257d28b61a9c",
@@ -1265,14 +1265,14 @@
 			"revisionTime": "2019-04-12T11:37:27Z"
 		},
 		{
-			"checksumSHA1": "UwLPI4qEs8cBU0CNw+/99/F1rN0=",
+			"checksumSHA1": "Qw4qdlZHCnBurAPPrSt+EKPIngM=",
 			"origin": "github.com/hashicorp/terraform/vendor/golang.org/x/text/unicode/bidi",
 			"path": "golang.org/x/text/unicode/bidi",
 			"revision": "1c95b21c6cfffc50cb6b3c3c23b2257d28b61a9c",
 			"revisionTime": "2019-04-12T11:37:27Z"
 		},
 		{
-			"checksumSHA1": "hLP6GY9wPeMoDoLado5xKAQtXDA=",
+			"checksumSHA1": "gra64bhQn4joYQMtrvihqTwqkM0=",
 			"origin": "github.com/hashicorp/terraform/vendor/golang.org/x/text/unicode/norm",
 			"path": "golang.org/x/text/unicode/norm",
 			"revision": "1c95b21c6cfffc50cb6b3c3c23b2257d28b61a9c",


### PR DESCRIPTION
This should fix #73 

One problem I still have is that I have to hardcode the token into the headers like this
```hcl
  headers = {
    Authorization = "Token 123token123"
  }
```
this
```
    Authorization = "Token ${module.config.passwords.uptime.token}"
```
returns
```
Error: Unexpected response code '401': {"messages":{"errors":true,"error_code":"NOT_AUTHENTICATED","error_message":"Authentication credentials were not provided."}}
```
any ideas?