### PR TITLE
Fix use cookies

### DIFF
--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -46,7 +46,6 @@ type api_client struct {
 	username              string
 	password              string
 	headers               map[string]string
-	use_cookie            bool
 	timeout               int
 	id_attribute          string
 	create_method         string

--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -23,7 +23,6 @@ type apiClientOpt struct {
 	username              string
 	password              string
 	headers               map[string]string
-	use_cookie            bool
 	timeout               int
 	id_attribute          string
 	create_method         string

--- a/restapi/provider.go
+++ b/restapi/provider.go
@@ -156,7 +156,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		username:              d.Get("username").(string),
 		password:              d.Get("password").(string),
 		headers:               headers,
-		use_cookie:            d.Get("use_cookies").(bool),
+		use_cookies:           d.Get("use_cookies").(bool),
 		timeout:               d.Get("timeout").(int),
 		id_attribute:          d.Get("id_attribute").(string),
 		copy_keys:             copy_keys,


### PR DESCRIPTION
the documented provider options `use_cookies` did not worked at all because the used property in the client opts was not evaluated at all.