### PR TITLE
Add generated docs

### DIFF
--- a/docs/data-sources/object.md
+++ b/docs/data-sources/object.md
@@ -1,0 +1,35 @@
+---
+page_title: "restapi_object Data Source - terraform-provider-restapi"
+subcategory: ""
+description: |-
+  
+---
+
+# Data Source `restapi_object`
+
+
+
+
+
+## Schema
+
+### Required
+
+- **path** (String, Required) The API path on top of the base URL set in the provider that represents objects of this type on the API server.
+- **search_key** (String, Required) When reading search results from the API, this key is used to identify the specific record to read. This should be a unique record such as 'name'. Similar to results_key, the value may be in the format of 'field/field/field' to search for data deeper in the returned object.
+- **search_value** (String, Required) The value of 'search_key' will be compared to this value to determine if the correct object was found. Example: if 'search_key' is 'name' and 'search_value' is 'foo', the record in the array returned by the API with name=foo will be used.
+
+### Optional
+
+- **debug** (Boolean, Optional) Whether to emit verbose debug output while working with the API object on the server.
+- **id** (String, Optional) The ID of this resource.
+- **id_attribute** (String, Optional) Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)
+- **query_string** (String, Optional) An optional query string to send when performing the search.
+- **results_key** (String, Optional) When issuing a GET to the path, this JSON key is used to locate the results array. The format is 'field/field/field'. Example: 'results/values'. If omitted, it is assumed the results coming back are already an array and are to be used exactly as-is.
+
+### Read-only
+
+- **api_data** (Map of String, Read-only) After data from the API server is read, this map will include k/v pairs usable in other terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).
+- **api_response** (String, Read-only) The raw body of the HTTP response from the last read of the object.
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+---
+page_title: "restapi Provider"
+subcategory: ""
+description: |-
+  
+---
+
+# restapi Provider
+
+
+
+
+
+## Schema
+
+### Required
+
+- **uri** (String, Required) URI of the REST API endpoint. This serves as the base of all requests.
+
+### Optional
+
+- **copy_keys** (List of String, Optional) When set, any PUT to the API for an object will copy these keys from the data the provider has gathered about the object. This is useful if internal API information must also be provided with updates, such as the revision of the object.
+- **create_method** (String, Optional) Defaults to `POST`. The HTTP method used to CREATE objects of this type on the API server.
+- **create_returns_object** (Boolean, Optional) Set this when the API returns the object created only on creation operations (POST). This is used by the provider to refresh internal data structures.
+- **debug** (Boolean, Optional) Enabling this will cause lots of debug information to be printed to STDOUT by the API client.
+- **destroy_method** (String, Optional) Defaults to `DELETE`. The HTTP method used to DELETE objects of this type on the API server.
+- **headers** (Map of String, Optional) A map of header names and values to set on all outbound requests. This is useful if you want to use a script via the 'external' provider or provide a pre-approved token or change Content-Type from `application/json`. If `username` and `password` are set and Authorization is one of the headers defined here, the BASIC auth credentials take precedence.
+- **id_attribute** (String, Optional) When set, this key will be used to operate on REST objects. For example, if the ID is set to 'name', changes to the API object will be to http://foo.com/bar/VALUE_OF_NAME. This value may also be a '/'-delimeted path to the id attribute if it is multple levels deep in the data (such as `attributes/id` in the case of an object `{ "attributes": { "id": 1234 }, "config": { "name": "foo", "something": "bar"}}`
+- **insecure** (Boolean, Optional) When using https, this disables TLS verification of the host.
+- **password** (String, Optional) When set, will use this password for BASIC auth to the API.
+- **rate_limit** (Number, Optional) Set this to limit the number of requests per second made to the API.
+- **read_method** (String, Optional) Defaults to `GET`. The HTTP method used to READ objects of this type on the API server.
+- **timeout** (Number, Optional) When set, will cause requests taking longer than this time (in seconds) to be aborted.
+- **update_method** (String, Optional) Defaults to `PUT`. The HTTP method used to UPDATE objects of this type on the API server.
+- **use_cookies** (Boolean, Optional) Enable cookie jar to persist session.
+- **username** (String, Optional) When set, will use this username for BASIC auth to the API.
+- **write_returns_object** (Boolean, Optional) Set this when the API returns the object created on all write operations (POST, PUT). This is used by the provider to refresh internal data structures.
+- **xssi_prefix** (String, Optional) Trim the xssi prefix from response string, if present, before parsing.

--- a/docs/resources/object.md
+++ b/docs/resources/object.md
@@ -1,0 +1,44 @@
+---
+page_title: "restapi_object Resource - terraform-provider-restapi"
+subcategory: ""
+description: |-
+  
+---
+
+# Resource `restapi_object`
+
+
+
+
+
+## Schema
+
+### Required
+
+- **data** (String, Required) Valid JSON data that this provider will manage with the API server.
+- **path** (String, Required) The API path on top of the base URL set in the provider that represents objects of this type on the API server.
+
+### Optional
+
+- **create_method** (String, Optional) Defaults to `create_method` set on the provider. Allows per-resource override of `create_method` (see `create_method` provider config documentation)
+- **create_path** (String, Optional) Defaults to `path`. The API path that represents where to CREATE (POST) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object if the data contains the `id_attribute`.
+- **debug** (Boolean, Optional) Whether to emit verbose debug output while working with the API object on the server.
+- **destroy_method** (String, Optional) Defaults to `destroy_method` set on the provider. Allows per-resource override of `destroy_method` (see `destroy_method` provider config documentation)
+- **destroy_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to DESTROY (DELETE) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
+- **force_new** (List of String, Optional) Any changes to these values will result in recreating the resource instead of updating.
+- **id** (String, Optional) The ID of this resource.
+- **id_attribute** (String, Optional) Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)
+- **object_id** (String, Optional) Defaults to the id learned by the provider during normal operations and `id_attribute`. Allows you to set the id manually. This is used in conjunction with the `*_path` attributes.
+- **read_method** (String, Optional) Defaults to `read_method` set on the provider. Allows per-resource override of `read_method` (see `read_method` provider config documentation)
+- **read_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to READ (GET) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
+- **read_search** (Map of String, Optional) Custom search for `read_path`. This map will take `search_key`, `search_value`, `results_key` and `query_string` (see datasource config documentation)
+- **update_method** (String, Optional) Defaults to `update_method` set on the provider. Allows per-resource override of `update_method` (see `update_method` provider config documentation)
+- **update_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to UPDATE (PUT) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
+
+### Read-only
+
+- **api_data** (Map of String, Read-only) After data from the API server is read, this map will include k/v pairs usable in other terraform resources as readable objects. Currently the value is the golang fmt package's representation of the value (simple primitives are set as expected, but complex types like arrays and maps contain golang formatting).
+- **api_response** (String, Read-only) The raw body of the HTTP response from the last read of the object.
+- **create_response** (String, Read-only) The raw body of the HTTP response returned when creating the object.
+
+


### PR DESCRIPTION
I fixed the issues in the [docs tool](https://github.com/hashicorp/terraform-plugin-docs). For generating docs it does require some code updates, but I figured to fix #85 I'd at least PR up the generated docs content and we can discuss the SDK version bump (to [terraform-plugin-sdk v2.0](https://github.com/hashicorp/terraform-plugin-sdk)) in another PR.