### PR TITLE
Add Terraform Registry support v2.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,56 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Install and configure GoReleaser
+        env:
+          GORELEASER_VERSION: '0.161.1'
+        run: |
+          curl -sL -o goreleaser_amd64.deb "https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_amd64.deb"
+          sudo dpkg -i goreleaser_amd64.deb
+          rm -f goreleaser_amd64.deb
+
+      - name: Import GPG key
+        id: import_gpg
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          mkdir -p ~/.gnupg
+          chmod 0700 ~/.gnupg
+          cat << EOF > ~/.gnupg/gpg.conf
+          use-agent
+          pinentry-mode loopback
+          EOF
+          echo "$GPG_PRIVATE_KEY" | base64 -d | gpg --batch --allow-secret-key-import --import
+          gpg --keyid-format LONG --list-secret-keys
+          cat << EOF > ~/.gnupg/gpg-agent.conf
+          default-cache-ttl 7200
+          max-cache-ttl 31536000
+          allow-loopback-pinentry
+          allow-preset-passphrase
+          EOF
+          echo RELOADAGENT | gpg-connect-agent
+          printf '%s' "$GPG_PASSPHRASE" > /tmp/.gpg_passphrase
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
+        run: |
+          goreleaser release --parallelism 2 --rm-dist --timeout 1h

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,48 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--passphrase-fd"
+      - "0"
+      - "--detach-sign"
+      - "${artifact}"
+    stdin_file: /tmp/.gpg_passphrase
+release:
+  draft: false
+changelog:
+  skip: true


### PR DESCRIPTION
This is continuation of #114
(I've deleted the fork and couldn't figure out a way how to make changes to that PR)

This PR:
- Adds support for [Terraform Registry](https://www.terraform.io/docs/registry/providers/index.html)
- Closes #85
- Difference from #114 
  - Removed action that was resposible for signing releases, substituted it with shell commands
  - Replaced go releaser action with go releaser binary
  - Renamed secret `PASSPHRASE` to `GPG_PASSPHRASE` for consistency
  - Added `GPG_FINGERPRINT` secret as a requirement
  - Removed unnecessary comments

**Requirements summary**

- [Create GPG key](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/generating-a-new-gpg-key)
  - Steps 1 - 9
- [Repository](https://www.terraform.io/docs/registry/providers/publishing.html#github-actions-preferred-)
  - Go to `Settings > Secrets` in your repository, and add the following secrets
    - `GPG_PRIVATE_KEY` - Your ASCII-armored GPG private key encoded in **base64**. You can export this with `gpg --armor --export-secret-keys [key ID or email] | base64` 
    - `GPG_PASSPHRASE` The passphrase for your GPG private key.
    - `GPG_FINGERPRINT` - fingerprint of you key `gpg --fingerprint [key ID or email]`
- [Terraform Registry](https://www.terraform.io/docs/registry/providers/publishing.html#preparing-and-adding-a-signing-key)
  - Export your public key in ASCII-armor format using the following command `gpg --armor --export "{Key ID or email address}"`
  - Import GPG key under Settings -> Signing Keys in Terraform Registry

- Tag the release
- Wait for the build to complete
- Import provider in Terraform Registry