### PR TITLE
Fixed error with example on terraform 1.15

### DIFF
--- a/examples/provider_with_headers.tf
+++ b/examples/provider_with_headers.tf
@@ -18,13 +18,14 @@ provider "restapi" {
   debug                = true
   write_returns_object = true
 
-  headers {
+  headers = {
     X-Internal-Client = "abc123"
     Authorization = var.SECRET_TOKEN
   }
 }
 
 resource "restapi_object" "Foo2" {
+  alias = restapi.restapi_headers
   path = "/api/objects"
   data = "{ \"id\": \"55555\", \"first\": \"Foo\", \"last\": \"Bar\" }"
 }


### PR DESCRIPTION
Faced the following error when running the example on terraform 1.15 (did not try other versions), also the resource `restapi_object` is missing the alias field for targeting  a specific provider

```
Error: Unsupported block type

  on main.tf line 21, in provider "restapi":
  21:   headers {

Blocks of type "headers" are not expected here. Did you mean to define
argument "headers"? If so, use the equals sign to assign it a value.
```