### PR TITLE
Solution for the error with an empty response

### DIFF
--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -13,6 +13,7 @@ import (
 	"net/http/cookiejar"
 	"strings"
 	"time"
+    "encoding/json"
 
 	"golang.org/x/oauth2/clientcredentials"
 	"golang.org/x/time/rate"
@@ -298,6 +299,13 @@ func (client *APIClient) sendRequest(method string, path string, data string) (s
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return body, fmt.Errorf("unexpected response code '%d': %s", resp.StatusCode, body)
+	}
+
+	if body == "" {
+		mapD := map[string]string{"response": ""}
+		body2, _ := json.Marshal(mapD)
+    	body := string(body2)
+		return body, nil
 	}
 
 	return body, nil


### PR DESCRIPTION
Solution for the error "invalid JSON: unexpected end of JSON input" with an empty response.

When a PUT type request was made and the response was empty, the terraform resources presented the error "invalid JSON: unexpected end of JSON input".
To solve it I have added an if that checks said output, and if it is empty add a json "{" response ":" "}"