### PR TITLE
Allowed to set optional EndpointParams with OAuth credentials (e.g. required by MS Azure)

### DIFF
--- a/examples/ms_azure.tf
+++ b/examples/ms_azure.tf
@@ -1,0 +1,16 @@
+provider "restapi" {
+  alias                = "restapi_ms_azure"
+  uri                  = "https://management.azure.com/subscriptions/${var.subscription_id}/"
+  debug                = true
+  write_returns_object = true
+
+  oauth_client_credentials {
+      oauth_client_id       = "example"
+      oauth_client_secret   = "example"
+      oauth_token_endpoint  = "https://login.microsoftonline.com/${var.tenant_id}/oauth2/token"
+      oauth_scopes          = ["openid"]
+      oauth_endpoint_params = {
+        resource = "https://management.core.windows.net"
+      }
+  }
+}

--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
 	"strings"
 	"time"
 
@@ -40,6 +41,7 @@ type apiClientOpt struct {
 	oauthClientSecret   string
 	oauthScopes         []string
 	oauthTokenURL       string
+	oauthEndpointParams url.Values
 	certFile            string
 	keyFile             string
 	debug               bool
@@ -156,10 +158,11 @@ func NewAPIClient(opt *apiClientOpt) (*APIClient, error) {
 
 	if opt.oauthClientID != "" && opt.oauthClientSecret != "" && opt.oauthTokenURL != "" {
 		client.oauthConfig = &clientcredentials.Config{
-			ClientID:     opt.oauthClientID,
-			ClientSecret: opt.oauthClientSecret,
-			TokenURL:     opt.oauthTokenURL,
-			Scopes:       opt.oauthScopes,
+			ClientID:     		opt.oauthClientID,
+			ClientSecret: 		opt.oauthClientSecret,
+			TokenURL:     		opt.oauthTokenURL,
+			Scopes:       		opt.oauthScopes,
+			EndpointParams:		opt.oauthEndpointParams,
 		}
 	}
 

--- a/restapi/provider.go
+++ b/restapi/provider.go
@@ -3,6 +3,7 @@ package restapi
 import (
 	"fmt"
 	"math"
+	"net/url"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -156,6 +157,12 @@ func Provider() terraform.ResourceProvider {
 							Optional:    true,
 							Description: "scopes",
 						},
+						"oauth_endpoint_params": {
+							Type:        schema.TypeMap,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+							Description: "endpoint params to provide additional data not required by all oauth providers",
+						},
 					},
 				},
 			},
@@ -239,6 +246,14 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		opt.oauthClientSecret = oauthConfig["oauth_client_secret"].(string)
 		opt.oauthTokenURL = oauthConfig["oauth_token_endpoint"].(string)
 		opt.oauthScopes = expandStringSet(oauthConfig["oauth_scopes"].([]interface{}))
+
+		if iOauthEndpointParams := oauthConfig["oauth_endpoint_params"]; iOauthEndpointParams != nil {
+			oauthEndpointParamValues := url.Values{}
+			for k, v := range iOauthEndpointParams.(map[string]interface{}) {
+				oauthEndpointParamValues.Set(k, v.(string))
+			}
+			opt.oauthEndpointParams = oauthEndpointParamValues
+		}
 	}
 	if v, ok := d.GetOk("cert_file"); ok {
 		opt.certFile = v.(string)


### PR DESCRIPTION
Hi,

not a Go expert yet, so please be patient with my proposal. I will try to incorporate your suggestions as best as I can.

We plan on using the provider to automate some Azure resources which are not yet supported in any other terraform provider. However, the access tokens obtained via OAuth must set a special `resouce`. We therefore added a new optional property in the OAuth section which allows to specify those. The property is already supported in the library `golang.org/x/oauth2/clientcredentials`, so we are only exposing it here as well.

An example how to use this provider with Microsoft Azure OAuth is included.

Thanks
Cedric