### PR TITLE
fix handling of server-deletes resulting in 404s

### DIFF
--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -285,7 +285,7 @@ func (obj *APIObject) readObject() error {
 
 	resultString, err := obj.apiClient.sendRequest(obj.readMethod, strings.Replace(getPath, "{id}", obj.id, -1), "")
 	if err != nil {
-		if strings.Contains(err.Error(), "Unexpected response code '404'") {
+		if strings.Contains(err.Error(), "unexpected response code '404'") {
 			log.Printf("api_object.go: 404 error while refreshing state for '%s' at path '%s'. Removing from state.", obj.id, obj.getPath)
 			obj.id = ""
 			return nil

--- a/restapi/api_object_test.go
+++ b/restapi/api_object_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/Mastercard/terraform-provider-restapi/fakeserver"
@@ -220,11 +219,8 @@ func TestAPIObject(t *testing.T) {
 		}
 		testingObjects["pet"].deleteObject()
 		err = testingObjects["pet"].readObject()
-		if err == nil {
-			t.Fatalf("api_object_test.go: 'pet' object deleted, but a subsequent read did not return an error!\n")
-		}
-		if !strings.Contains(err.Error(), "404") {
-			t.Fatalf("api_object_test.go: 'pet' object deleted, but the resulting error was not a 404 during read! What came back was: %v\n", err)
+		if err != nil {
+			t.Fatalf("api_object_test.go: 'pet' object deleted, but an error was returned when reading the object (expected the provider to cope with this!\n")
 		}
 	})
 


### PR DESCRIPTION
d61a16eaa3ed19378c5f2c9dd1f04af0eaf66b47 initially established the behaviour that server-side deletes or a REST resource are handled gracefully be the plugin (by re-creating the resource instead of failing in `terraform plan`) but this behavour got broken with ef7f07a2334a87ff50c42625bc63934affbf6646.

The test case that was verifying this also got changed in c43d333652afa539d5b8c8c42233c96f26f2aaf6 so this PR reverts that change as well to establish the original behaviour.


Ultimately, the error-matching via strings does not seem the most stable choice for the future (as shown by ef7f07a2334a87ff50c42625bc63934affbf6646), but refactoring this is outside of the scope of this PR.