### PR TITLE
Added read_data and enforce_data parameters

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4/go.mod h1:chxPXzS
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 h1:y8Gs8CzNfDF5AZvjr+5UyGQvQEBL7pwo+v+wX6q9JI8=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
+github.com/Mastercard/terraform-provider-restapi v1.16.2 h1:7NkBL9/aLn2jUPmpE+ms3o36XXuKd/6JaXPFwQkX15w=
+github.com/Mastercard/terraform-provider-restapi v1.16.2/go.mod h1:ICQ7AhJxNbH00GpQfOrcqFnz8GtCFG+KQQFW5wmAnvc=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292 h1:tuQ7w+my8a8mkwN7x2TSd7OzTjkZ7rAeSyH4xncuAMI=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=

--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -29,6 +29,7 @@ type apiClientOpt struct {
 	idAttribute         string
 	createMethod        string
 	readMethod          string
+	readData            string
 	updateMethod        string
 	destroyMethod       string
 	copyKeys            []string
@@ -58,6 +59,7 @@ type APIClient struct {
 	idAttribute         string
 	createMethod        string
 	readMethod          string
+	readData            string
 	updateMethod        string
 	destroyMethod       string
 	copyKeys            []string
@@ -147,6 +149,7 @@ func NewAPIClient(opt *apiClientOpt) (*APIClient, error) {
 		idAttribute:         opt.idAttribute,
 		createMethod:        opt.createMethod,
 		readMethod:          opt.readMethod,
+		readData:            opt.readData,
 		updateMethod:        opt.updateMethod,
 		destroyMethod:       opt.destroyMethod,
 		copyKeys:            opt.copyKeys,

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -18,6 +18,7 @@ type apiObjectOpts struct {
 	putPath       string
 	createMethod  string
 	readMethod    string
+	readData      string
 	updateMethod  string
 	destroyMethod string
 	deletePath    string
@@ -38,6 +39,7 @@ type APIObject struct {
 	putPath       string
 	createMethod  string
 	readMethod    string
+	readData      string
 	updateMethod  string
 	destroyMethod string
 	deletePath    string
@@ -75,6 +77,9 @@ func NewAPIObject(iClient *APIClient, opts *apiObjectOpts) (*APIObject, error) {
 	if opts.readMethod == "" {
 		opts.readMethod = iClient.readMethod
 	}
+	if opts.readData == "" {
+		opts.readData = iClient.readData
+	}
 	if opts.updateMethod == "" {
 		opts.updateMethod = iClient.updateMethod
 	}
@@ -105,6 +110,7 @@ func NewAPIObject(iClient *APIClient, opts *apiObjectOpts) (*APIObject, error) {
 		putPath:       opts.putPath,
 		createMethod:  opts.createMethod,
 		readMethod:    opts.readMethod,
+		readData:      opts.readData,
 		updateMethod:  opts.updateMethod,
 		destroyMethod: opts.destroyMethod,
 		deletePath:    opts.deletePath,
@@ -164,6 +170,7 @@ func (obj *APIObject) toString() string {
 	buffer.WriteString(fmt.Sprintf("query_string: %s\n", obj.queryString))
 	buffer.WriteString(fmt.Sprintf("create_method: %s\n", obj.createMethod))
 	buffer.WriteString(fmt.Sprintf("read_method: %s\n", obj.readMethod))
+	buffer.WriteString(fmt.Sprintf("read_data: %s\n", obj.readData))
 	buffer.WriteString(fmt.Sprintf("update_method: %s\n", obj.updateMethod))
 	buffer.WriteString(fmt.Sprintf("destroy_method: %s\n", obj.destroyMethod))
 	buffer.WriteString(fmt.Sprintf("debug: %t\n", obj.debug))
@@ -283,7 +290,7 @@ func (obj *APIObject) readObject() error {
 		getPath = fmt.Sprintf("%s?%s", obj.getPath, obj.queryString)
 	}
 
-	resultString, err := obj.apiClient.sendRequest(obj.readMethod, strings.Replace(getPath, "{id}", obj.id, -1), "")
+	resultString, err := obj.apiClient.sendRequest(obj.readMethod, strings.Replace(getPath, "{id}", obj.id, -1), obj.readData)
 	if err != nil {
 		if strings.Contains(err.Error(), "Unexpected response code '404'") {
 			log.Printf("api_object.go: 404 error while refreshing state for '%s' at path '%s'. Removing from state.", obj.id, obj.getPath)


### PR DESCRIPTION
This PR adds two features:

* read_data => Allows specifying a 'data/body' to send along with read requests.
* enforce_data => which ensures re-creation of object in cases where it ends up with some attribute different from the ones initially used to create it (as defined at 'data')

Regards
Pablo