### PR TITLE
Add support for destroy_data and update_data to be sent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,12 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your
+# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
 #
-# You will need to pass the `--batch` flag to `gpg` in your signing step
+# You will need to pass the `--batch` flag to `gpg` in your signing step 
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: release
@@ -14,36 +14,39 @@ on:
   push:
     tags:
       - 'v*'
+permissions:
+  contents: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version-file: 'go.mod'
+          cache: true
       -
         name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.8.1
+        uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
-          args: release --parallelism 2 --rm-dist --timeout 1h --release-notes .release_info.md
+          args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,12 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
+# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
 #
-# You will need to pass the `--batch` flag to `gpg` in your signing step 
+# You will need to pass the `--batch` flag to `gpg` in your signing step
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: release
@@ -44,9 +44,8 @@ jobs:
         uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --parallelism 2 --rm-dist --timeout 1h --release-notes .release_info.md
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          

--- a/docs/resources/object.md
+++ b/docs/resources/object.md
@@ -24,6 +24,7 @@ description: |-
 - **create_path** (String, Optional) Defaults to `path`. The API path that represents where to CREATE (POST) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object if the data contains the `id_attribute`.
 - **debug** (Boolean, Optional) Whether to emit verbose debug output while working with the API object on the server.
 - **destroy_method** (String, Optional) Defaults to `destroy_method` set on the provider. Allows per-resource override of `destroy_method` (see `destroy_method` provider config documentation)
+- **destroy_data** (String, Optional) Valid JSON data that this provider will send to the API server on DESTROY (DELETE) operations.
 - **destroy_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to DESTROY (DELETE) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
 - **force_new** (List of String, Optional) Any changes to these values will result in recreating the resource instead of updating.
 - **id** (String, Optional) The ID of this resource.

--- a/docs/resources/object.md
+++ b/docs/resources/object.md
@@ -35,6 +35,7 @@ description: |-
 - **read_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to READ (GET) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
 - **read_search** (Map of String, Optional) Custom search for `read_path`. This map will take `search_key`, `search_value`, `results_key` and `query_string` (see datasource config documentation)
 - **update_method** (String, Optional) Defaults to `update_method` set on the provider. Allows per-resource override of `update_method` (see `update_method` provider config documentation)
+- **update_data** (String, Optional) Valid JSON data that this provider will send to the API server on UPDATE (PUT) operations. Allows override of `data` on UPDATE (PUT) operations.
 - **update_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to UPDATE (PUT) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
 
 ### Read-only

--- a/docs/resources/object.md
+++ b/docs/resources/object.md
@@ -24,7 +24,7 @@ description: |-
 - **create_path** (String, Optional) Defaults to `path`. The API path that represents where to CREATE (POST) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object if the data contains the `id_attribute`.
 - **debug** (Boolean, Optional) Whether to emit verbose debug output while working with the API object on the server.
 - **destroy_method** (String, Optional) Defaults to `destroy_method` set on the provider. Allows per-resource override of `destroy_method` (see `destroy_method` provider config documentation)
-- **destroy_data** (String, Optional) Valid JSON data that this provider will send to the API server on DESTROY (DELETE) operations.
+- **destroy_data** (String, Optional) Valid JSON data that this provider will send to the API server on DESTROY (DELETE) operations. If not set, defaults to the value of `data`.
 - **destroy_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to DESTROY (DELETE) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
 - **force_new** (List of String, Optional) Any changes to these values will result in recreating the resource instead of updating.
 - **id** (String, Optional) The ID of this resource.
@@ -35,7 +35,7 @@ description: |-
 - **read_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to READ (GET) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
 - **read_search** (Map of String, Optional) Custom search for `read_path`. This map will take `search_key`, `search_value`, `results_key` and `query_string` (see datasource config documentation)
 - **update_method** (String, Optional) Defaults to `update_method` set on the provider. Allows per-resource override of `update_method` (see `update_method` provider config documentation)
-- **update_data** (String, Optional) Valid JSON data that this provider will send to the API server on UPDATE (PUT) operations. Allows override of `data` on UPDATE (PUT) operations.
+- **update_data** (String, Optional) Valid JSON data that this provider will send to the API server on UPDATE (PUT) operations. If not set, defaults to the value of `data`.
 - **update_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to UPDATE (PUT) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
 
 ### Read-only

--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -30,6 +30,7 @@ type apiClientOpt struct {
 	createMethod        string
 	readMethod          string
 	updateMethod        string
+	updateData          string
 	destroyMethod       string
 	destroyData         string
 	copyKeys            []string
@@ -62,6 +63,7 @@ type APIClient struct {
 	createMethod        string
 	readMethod          string
 	updateMethod        string
+	updateData          string
 	destroyMethod       string
 	destroyData         string
 	copyKeys            []string
@@ -160,6 +162,7 @@ func NewAPIClient(opt *apiClientOpt) (*APIClient, error) {
 		createMethod:        opt.createMethod,
 		readMethod:          opt.readMethod,
 		updateMethod:        opt.updateMethod,
+		updateData:          opt.updateData,
 		destroyMethod:       opt.destroyMethod,
 		destroyData:         opt.destroyData,
 		copyKeys:            opt.copyKeys,

--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -31,6 +31,7 @@ type apiClientOpt struct {
 	readMethod          string
 	updateMethod        string
 	destroyMethod       string
+	destroyData         string
 	copyKeys            []string
 	writeReturnsObject  bool
 	createReturnsObject bool
@@ -62,6 +63,7 @@ type APIClient struct {
 	readMethod          string
 	updateMethod        string
 	destroyMethod       string
+	destroyData         string
 	copyKeys            []string
 	writeReturnsObject  bool
 	createReturnsObject bool
@@ -159,6 +161,7 @@ func NewAPIClient(opt *apiClientOpt) (*APIClient, error) {
 		readMethod:          opt.readMethod,
 		updateMethod:        opt.updateMethod,
 		destroyMethod:       opt.destroyMethod,
+		destroyData:         opt.destroyData,
 		copyKeys:            opt.copyKeys,
 		writeReturnsObject:  opt.writeReturnsObject,
 		createReturnsObject: opt.createReturnsObject,

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -53,12 +53,12 @@ type APIObject struct {
 	/* Set internally */
 	data        map[string]interface{} /* Data as managed by the user */
 	updateData  map[string]interface{} /* Update data as managed by the user */
-	destroyData map[string]interface{} /* Update data as managed by the user */
+	destroyData map[string]interface{} /* Destroy data as managed by the user */
 	apiData     map[string]interface{} /* Data as available from the API */
 	apiResponse string
 }
 
-//NewAPIObject makes an APIobject to manage a RESTful object in an API
+// NewAPIObject makes an APIobject to manage a RESTful object in an API
 func NewAPIObject(iClient *APIClient, opts *apiObjectOpts) (*APIObject, error) {
 	if opts.debug {
 		log.Printf("api_object.go: Constructing debug api_object\n")
@@ -208,9 +208,12 @@ func (obj *APIObject) toString() string {
 	return buffer.String()
 }
 
-/* Centralized function to ensure that our data as managed by
-   the api_object is updated with data that has come back from
-   the API */
+/*
+Centralized function to ensure that our data as managed by
+
+	the api_object is updated with data that has come back from
+	the API
+*/
 func (obj *APIObject) updateState(state string) error {
 	if obj.debug {
 		log.Printf("api_object.go: Updating API object state to '%s'\n", state)

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -20,6 +20,7 @@ type apiObjectOpts struct {
 	readMethod    string
 	updateMethod  string
 	destroyMethod string
+	destroyData   string
 	deletePath    string
 	searchPath    string
 	queryString   string
@@ -40,6 +41,7 @@ type APIObject struct {
 	readMethod    string
 	updateMethod  string
 	destroyMethod string
+	destroyData   string
 	deletePath    string
 	searchPath    string
 	queryString   string
@@ -81,7 +83,9 @@ func NewAPIObject(iClient *APIClient, opts *apiObjectOpts) (*APIObject, error) {
 	if opts.destroyMethod == "" {
 		opts.destroyMethod = iClient.destroyMethod
 	}
-
+	if opts.destroyData == "" {
+		opts.destroyData = iClient.destroyData
+	}
 	if opts.postPath == "" {
 		opts.postPath = opts.path
 	}
@@ -107,6 +111,7 @@ func NewAPIObject(iClient *APIClient, opts *apiObjectOpts) (*APIObject, error) {
 		readMethod:    opts.readMethod,
 		updateMethod:  opts.updateMethod,
 		destroyMethod: opts.destroyMethod,
+		destroyData:   opts.destroyData,
 		deletePath:    opts.deletePath,
 		searchPath:    opts.searchPath,
 		queryString:   opts.queryString,
@@ -166,6 +171,7 @@ func (obj *APIObject) toString() string {
 	buffer.WriteString(fmt.Sprintf("read_method: %s\n", obj.readMethod))
 	buffer.WriteString(fmt.Sprintf("update_method: %s\n", obj.updateMethod))
 	buffer.WriteString(fmt.Sprintf("destroy_method: %s\n", obj.destroyMethod))
+	buffer.WriteString(fmt.Sprintf("destroy_data: %s\n", obj.destroyData))
 	buffer.WriteString(fmt.Sprintf("debug: %t\n", obj.debug))
 	buffer.WriteString(fmt.Sprintf("read_search: %s\n", spew.Sdump(obj.readSearch)))
 	buffer.WriteString(fmt.Sprintf("data: %s\n", spew.Sdump(obj.data)))
@@ -368,7 +374,7 @@ func (obj *APIObject) deleteObject() error {
 		deletePath = fmt.Sprintf("%s?%s", obj.deletePath, obj.queryString)
 	}
 
-	_, err := obj.apiClient.sendRequest(obj.destroyMethod, strings.Replace(deletePath, "{id}", obj.id, -1), "")
+	_, err := obj.apiClient.sendRequest(obj.destroyMethod, strings.Replace(deletePath, "{id}", obj.id, -1), obj.destroyData)
 	if err != nil {
 		return err
 	}

--- a/restapi/api_object_test.go
+++ b/restapi/api_object_test.go
@@ -212,6 +212,21 @@ func TestAPIObject(t *testing.T) {
 		}
 	})
 
+	/* Update once more with update_data */
+	t.Run("update_object_with_update_data", func(t *testing.T) {
+		if testDebug {
+			log.Printf("api_object_test.go: Testing update_object() with update_data")
+		}
+		testingObjects["minimal"].updateData["Thing"] = "knife"
+		testingObjects["minimal"].updateObject()
+		if err != nil {
+			t.Fatalf("api_object_test.go: Failed in update_object() test: %s", err)
+		} else if testingObjects["minimal"].apiData["Thing"] != "knife" {
+			t.Fatalf("api_object_test.go: Failed to update 'Thing' field of 'minimal' object. Expected it to be '%s' but it is '%s'\nFull obj: %+v\n",
+				"knife", testingObjects["minimal"].apiData["Thing"], testingObjects["minimal"])
+		}
+	})
+
 	/* Delete one and make sure a 404 follows */
 	t.Run("delete_object", func(t *testing.T) {
 		if testDebug {
@@ -233,9 +248,9 @@ func TestAPIObject(t *testing.T) {
 		err = testingObjects["pet"].createObject()
 		if err != nil {
 			t.Fatalf("api_object_test.go: Failed in create_object() test: %s", err)
-		} else if testingObjects["minimal"].apiData["Thing"] != "spoon" {
+		} else if testingObjects["minimal"].apiData["Thing"] != "knife" {
 			t.Fatalf("api_object_test.go: Failed to update 'Thing' field of 'minimal' object. Expected it to be '%s' but it is '%s'\nFull obj: %+v\n",
-				"spoon", testingObjects["minimal"].apiData["Thing"], testingObjects["minimal"])
+				"knife", testingObjects["minimal"].apiData["Thing"], testingObjects["minimal"])
 		}
 
 		/* verify it's there */

--- a/restapi/api_object_test.go
+++ b/restapi/api_object_test.go
@@ -296,7 +296,7 @@ func TestAPIObject(t *testing.T) {
 		if testDebug {
 			log.Printf("api_object_test.go: Testing delete_object() with destroy_data")
 		}
-		testingObjects["pet"].destroyData = "{\"destroy\": \"true\"}"
+		testingObjects["pet"].destroyData["destroy"] = "true"
 		testingObjects["pet"].deleteObject()
 		err = testingObjects["pet"].readObject()
 		if err != nil {

--- a/restapi/api_object_test.go
+++ b/restapi/api_object_test.go
@@ -276,6 +276,19 @@ func TestAPIObject(t *testing.T) {
 		}
 	})
 
+	/* Delete it again with destroy_data and make sure a 404 follows */
+	t.Run("delete_object_with_destroy_data", func(t *testing.T) {
+		if testDebug {
+			log.Printf("api_object_test.go: Testing delete_object() with destroy_data")
+		}
+		testingObjects["pet"].destroyData = "{\"destroy\": \"true\"}"
+		testingObjects["pet"].deleteObject()
+		err = testingObjects["pet"].readObject()
+		if err != nil {
+			t.Fatalf("api_object_test.go: 'pet' object deleted, but an error was returned when reading the object (expected the provider to cope with this!\n")
+		}
+	})
+
 	if testDebug {
 		log.Println("api_object_test.go: Stopping HTTP server")
 	}

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -142,6 +142,23 @@ func resourceRestAPI() *schema.Resource {
 				ForceNew:    true,
 				Description: "Any changes to these values will result in recreating the resource instead of updating.",
 			},
+			"update_data": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Valid JSON data to pass during to update requests.",
+				Sensitive:   isDataSensitive,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					if v != "" {
+						data := make(map[string]interface{})
+						err := json.Unmarshal([]byte(v), &data)
+						if err != nil {
+							errs = append(errs, fmt.Errorf("update_data attribute is invalid JSON: %v", err))
+						}
+					}
+					return warns, errs
+				},
+			},
 			"destroy_data": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -381,6 +398,9 @@ func buildAPIObjectOpts(d *schema.ResourceData) (*apiObjectOpts, error) {
 	}
 	if v, ok := d.GetOk("update_method"); ok {
 		opts.updateMethod = v.(string)
+	}
+	if v, ok := d.GetOk("update_data"); ok {
+		opts.updateData = v.(string)
 	}
 	if v, ok := d.GetOk("destroy_method"); ok {
 		opts.destroyMethod = v.(string)

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -142,6 +142,23 @@ func resourceRestAPI() *schema.Resource {
 				ForceNew:    true,
 				Description: "Any changes to these values will result in recreating the resource instead of updating.",
 			},
+			"destroy_data": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Valid JSON data to pass during to destroy requests.",
+				Sensitive:   isDataSensitive,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					if v != "" {
+						data := make(map[string]interface{})
+						err := json.Unmarshal([]byte(v), &data)
+						if err != nil {
+							errs = append(errs, fmt.Errorf("destroy_data attribute is invalid JSON: %v", err))
+						}
+					}
+					return warns, errs
+				},
+			},
 		}, /* End schema */
 
 	}
@@ -367,6 +384,9 @@ func buildAPIObjectOpts(d *schema.ResourceData) (*apiObjectOpts, error) {
 	}
 	if v, ok := d.GetOk("destroy_method"); ok {
 		opts.destroyMethod = v.(string)
+	}
+	if v, ok := d.GetOk("destroy_data"); ok {
+		opts.destroyData = v.(string)
 	}
 	if v, ok := d.GetOk("destroy_path"); ok {
 		opts.deletePath = v.(string)


### PR DESCRIPTION
This PR is inspired by #177 and it adds one feature:
- destroy_data => Allows specifying a 'data/body' to send along with destroy/delete requests.

It could solve #174 I think.