### PR TITLE
Support reverting remote changes

### DIFF
--- a/restapi/delta_checker.go
+++ b/restapi/delta_checker.go
@@ -1,0 +1,97 @@
+package restapi
+
+import (
+	"reflect"
+	"strings"
+)
+
+/*
+ * Performs a deep comparison of two maps, returning true if there is a difference between them.
+ * Accepts a third argument that is a set of fields that are to be ignored when looking for differences.
+ */
+func hasDelta(mapA map[string]interface{}, mapB map[string]interface{}, ignoreList []string) bool {
+	// Keep a set of keys we've check in mapA, to reduce work when checking keys in mapB
+	checkedKeys := map[string]struct{} {}
+
+	for key, valA := range mapA {
+
+		checkedKeys[key] = struct{}{}
+
+		// If the ignore_list contains the current key, don't compare
+		if contains(ignoreList, key) {
+			continue
+		}
+
+		valB := mapB[key]
+
+		// If valA was a map, assert both values are maps
+		if reflect.TypeOf(valA).Kind() == reflect.Map {
+			subMapA, okA := valA.(map[string]interface{})
+			subMapB, okB := valB.(map[string]interface{})
+			if !okA || !okB {
+				return true
+			}
+			// Recursively compare
+			if hasDelta(subMapA, subMapB, _descendIgnoreList(key, ignoreList)) {
+				return true
+			}
+		} else if reflect.TypeOf(valA).Kind() == reflect.Slice {
+			// Since we don't support ignoring differences in lists (besides ignoring the list as a
+			// whole), it is safe to deep compare the two list values.
+			if ! reflect.DeepEqual(valA, valB) {
+				return true
+			}
+		} else {
+			if valA != valB {
+				return true
+			}
+		}
+
+	}
+
+	for key := range mapB {
+		// We may have already compared this key with mapA, and confirmed there is no difference.
+		_, alreadyChecked := checkedKeys[key]
+		if alreadyChecked {
+			continue
+		}
+
+		// If the ignore_list contains the current key, don't compare
+		if contains(ignoreList, key) {
+			continue
+		}
+
+		// If we've gotten here, that means mapB has an additional key that wasn't in mapA
+		return true
+	}
+
+	return false
+}
+
+/*
+ * Modifies an ignoreList to be relative to a descended path.
+ * E.g. given descendPath = "bar", and the ignoreList [foo, bar.alpha, bar.bravo], this returns [alpha, bravo]
+ */
+func _descendIgnoreList(descendPath string, ignoreList []string) []string {
+	newIgnoreList := make([]string, len(ignoreList))
+
+	for _, ignorePath := range ignoreList {
+		pathComponents := strings.Split(ignorePath, ".")
+		// If this ignorePath starts with the descendPath, remove the first component and keep the rest
+		if pathComponents[0] == descendPath {
+			modifiedPath := strings.Join(pathComponents[1:], ".")
+			newIgnoreList = append(newIgnoreList, modifiedPath)
+		}
+	}
+
+	return newIgnoreList
+}
+
+func contains(list []string, elem string) bool {
+    for _, a := range list {
+        if a == elem {
+            return true
+        }
+    }
+    return false
+}

--- a/restapi/delta_checker.go
+++ b/restapi/delta_checker.go
@@ -28,7 +28,6 @@ func getDelta(recordedResource map[string]interface{}, actualResource map[string
 		}
 
 		valActual := actualResource[key]
-
 		// If valRecorded was a map, assert both values are maps
 		if reflect.TypeOf(valRecorded).Kind() == reflect.Map {
 			subMapA, okA := valRecorded.(map[string]interface{})
@@ -36,11 +35,15 @@ func getDelta(recordedResource map[string]interface{}, actualResource map[string
 			if !okA || !okB {
 				modifiedResource[key] = valActual
 				hasChanges = true
+				continue
 			}
 			// Recursively compare
-			if modifiedSubResource, hasChange := getDelta(subMapA, subMapB, _descendIgnoreList(key, ignoreList)); hasChange {
+			deeperIgnoreList := _descendIgnoreList(key, ignoreList)
+			if modifiedSubResource, hasChange := getDelta(subMapA, subMapB, deeperIgnoreList); hasChange {
 				modifiedResource[key] = modifiedSubResource
 				hasChanges = true
+			} else {
+				modifiedResource[key] = valRecorded
 			}
 		} else if reflect.TypeOf(valRecorded).Kind() == reflect.Slice {
 			// Since we don't support ignoring differences in lists (besides ignoring the list as a
@@ -48,6 +51,8 @@ func getDelta(recordedResource map[string]interface{}, actualResource map[string
 			if ! reflect.DeepEqual(valRecorded, valActual) {
 				modifiedResource[key] = valActual
 				hasChanges = true
+			} else {
+				modifiedResource[key] = valRecorded
 			}
 		} else if valRecorded != valActual {
 				modifiedResource[key] = valActual

--- a/restapi/delta_checker_test.go
+++ b/restapi/delta_checker_test.go
@@ -261,7 +261,7 @@ func generateTypeConversionTests() []deltaTestCase {
 func TestHasDelta(t *testing.T) {
 	// Run the main test cases
 	for _, testCase := range deltaTestCases {
-		result := hasDelta(testCase.o1, testCase.o2, testCase.ignoreList)
+		_, result := getDelta(testCase.o1, testCase.o2, testCase.ignoreList)
 		if result != testCase.resultHasDelta {
 			t.Errorf("delta_checker_test.go: Test Case [%d:%s] wanted [%v] got [%v]", testCase.testId, testCase.testCase, testCase.resultHasDelta, result)
 		}
@@ -269,7 +269,7 @@ func TestHasDelta(t *testing.T) {
 
 	// Test type changes
 	for _, testCase := range generateTypeConversionTests() {
-		result := hasDelta(testCase.o1, testCase.o2, testCase.ignoreList)
+		_, result := getDelta(testCase.o1, testCase.o2, testCase.ignoreList)
 		if result != testCase.resultHasDelta {
 			t.Errorf("delta_checker_test.go: TYPE CONVERSION Test Case [%d:%s] wanted [%v] got [%v]", testCase.testId, testCase.testCase, testCase.resultHasDelta, result)
 		}

--- a/restapi/delta_checker_test.go
+++ b/restapi/delta_checker_test.go
@@ -1,0 +1,278 @@
+package restapi
+
+import (
+	"testing"
+	"fmt"
+	// "log"
+)
+
+// Creating a type alias to save some typing in the test cases
+type MapAny = map[string]interface{}
+
+type deltaTestCase struct {
+	testCase       string                 `json:"Test_case"`
+	testId         int                    `json:"Id"`
+	o1             map[string]interface{} `json:o1`
+	o2             map[string]interface{} `json:o2`
+	ignoreList     []string
+	resultHasDelta bool                   // True if the compared
+}
+
+var deltaTestCases = []deltaTestCase{
+
+	// Various cases where there are no changes
+	{
+		testCase:       "No change 1",
+		testId:         1,
+		o1:             MapAny{ "foo": "bar" },
+		o2:             MapAny{ "foo": "bar" },
+		ignoreList:     []string{},
+		resultHasDelta: false,
+	},
+
+	{
+		testCase:       "No change - nested object",
+		testId:         2,
+		o1:             MapAny{"foo":"bar", "inner": MapAny{"foo":"bar"} },
+		o2:             MapAny{"foo":"bar", "inner": MapAny{"foo":"bar"} },
+		ignoreList:     []string{},
+		resultHasDelta: false,
+	},
+
+	{
+		testCase:       "No change - has an array",
+		testId:         3,
+		o1:             MapAny{"foo":"bar", "list": []string{"foo", "bar"} },
+		o2:             MapAny{"foo":"bar", "list": []string{"foo", "bar"} },
+		ignoreList:     []string{},
+		resultHasDelta: false,
+	},
+
+	{
+		testCase:       "No change - more types",
+		testId:         4,
+		o1:             MapAny{"bool":true, "int": 4 },
+		o2:             MapAny{"bool":true, "int": 4 },
+		ignoreList:     []string{},
+		resultHasDelta: false,
+	},
+
+	// These test cases come in pairs or sets. Each test in the set will have
+	// the same o1 and o2 values. We'll first ensure that any changes by the
+	// server are detected without an ignore_list, then we'll test the same
+	// values again with one or more ignore_lists.
+
+	// Change a field
+
+	{
+		testCase:       "Server changes the value of a field",
+		testId:         5,
+		o1:             MapAny{"foo":"bar"},
+		o2:             MapAny{"foo":"changed"},
+		ignoreList:     []string{},
+		resultHasDelta: true,
+	},
+
+	{
+		testCase:       "Server changes the value of a field (ignored)",
+		testId:         6,
+		o1:             MapAny{"foo":"bar"},
+		o2:             MapAny{"foo":"changed"},
+		ignoreList:     []string{ "foo" },
+		resultHasDelta: false,
+	},
+
+	// Add a field
+
+	{
+		testCase:       "Server adds a field",
+		testId:         7,
+		o1:             MapAny{"foo":"bar"},
+		o2:             MapAny{"foo":"bar", "new":"field"},
+		ignoreList:     []string{},
+		resultHasDelta: true,
+	},
+
+	{
+		testCase:       "Server adds a field (ignored)",
+		testId:         8,
+		o1:             MapAny{"foo":"bar"},
+		o2:             MapAny{"foo":"bar", "new":"field"},
+		ignoreList:     []string{ "new" },
+		resultHasDelta: false,
+	},
+
+	// Remove a field
+
+	{
+		testCase:       "Server removes a field",
+		testId:         9,
+		o1:             MapAny{"foo":"bar", "id": "foobar"},
+		o2:             MapAny{"foo":"bar"},
+		ignoreList:     []string{},
+		resultHasDelta: true,
+	},
+
+	{
+		testCase:       "Server removes a field (ignored)",
+		testId:         10,
+		o1:             MapAny{"foo":"bar", "id": "foobar"},
+		o2:             MapAny{"foo":"bar"},
+		ignoreList:     []string{ "id" },
+		resultHasDelta: false,
+	},
+
+	// Deep fields
+
+	{
+		testCase:       "Server changes/adds/removes a deep field",
+		testId:         11,
+		o1:             MapAny{"outside": MapAny{"change":"a", "remove":"a"}},
+		o2:             MapAny{"outside": MapAny{"change":"b", "add":"a"}},
+		ignoreList:     []string{},
+		resultHasDelta: true,
+	},
+
+	{
+		testCase:       "Server changes/adds/removes a deep field (ignored)",
+		testId:         12,
+		o1:             MapAny{"outside": MapAny{"change":"a", "remove":"a"}},
+		o2:             MapAny{"outside": MapAny{"change":"b", "add":"a"}},
+		ignoreList:     []string{ "outside.change", "outside.add", "outside.remove" },
+		resultHasDelta: false,
+	},
+
+	// Similar to 12: make sure we notice a change to a deep field even when we ignore some of them
+	{
+		testCase:       "Server changes/adds/removes a deep field (ignored 2)",
+		testId:         13,
+		o1:             MapAny{"outside": MapAny{"watch":"me", "change":"a", "remove":"a"}},
+		o2:             MapAny{"outside": MapAny{"watch":"me_change","change":"b", "add":"a"}},
+		ignoreList:     []string{ "outside.change", "outside.add", "outside.remove" },
+		resultHasDelta: true,
+	},
+
+	// Similar to 12,13 but ignore the whole "outside"
+	{
+		testCase:       "Server changes/adds/removes a deep field (ignore root field)",
+		testId:         14,
+		o1:             MapAny{"outside": MapAny{"watch":"me", "change":"a", "remove":"a"}},
+		o2:             MapAny{"outside": MapAny{"watch":"me_change","change":"b", "add":"a"}},
+		ignoreList:     []string{ "outside" },
+		resultHasDelta: false,
+	},
+
+
+	// Basic List Changes
+	// Note: we don't support ignoring specific differences to lists - only ignoring the list as a whole
+	{
+		testCase:       "Server adds to list",
+		testId:         15,
+		o1:             MapAny{"list": []string{"foo", "bar"} },
+		o2:             MapAny{"list": []string{"foo", "bar", "baz"} },
+		ignoreList:     []string{},
+		resultHasDelta: true,
+	},
+
+	{
+		testCase:       "Server removes from list",
+		testId:         16,
+		o1:             MapAny{"list": []string{"foo", "bar"} },
+		o2:             MapAny{"list": []string{"foo"} },
+		ignoreList:     []string{},
+		resultHasDelta: true,
+	},
+
+	{
+		testCase:       "Server changes an item in the list",
+		testId:         17,
+		o1:             MapAny{"list": []string{"foo", "bar"} },
+		o2:             MapAny{"list": []string{"foo", "BAR"} },
+		ignoreList:     []string{},
+		resultHasDelta: true,
+	},
+
+	{
+		testCase:       "Server rearranges the list",
+		testId:         18,
+		o1:             MapAny{"list": []string{"foo", "bar"} },
+		o2:             MapAny{"list": []string{"bar", "foo"} },
+		ignoreList:     []string{},
+		resultHasDelta: true,
+	},
+
+	{
+		testCase:       "Server changes the list but we ignore the whole list",
+		testId:         19,
+		o1:             MapAny{"list": []string{"foo", "bar"} },
+		o2:             MapAny{"list": []string{"bar", "foo"} },
+		ignoreList:     []string{ "list" },
+		resultHasDelta: false,
+	},
+
+	// We don't currently support ignoring a change like this, but we could in the future with a syntax like `list[].val` similar to jq
+	{
+		testCase:       "Server changes a sub-value in a list of objects",
+		testId:         19,
+		o1:             MapAny{"list": []MapAny{ {"key":"foo", "val":"x"}, {"key":"bar", "val":"x"} } },
+		o2:             MapAny{"list": []MapAny{ {"key":"foo", "val":"Y"}, {"key":"bar", "val":"Z"} } },
+		ignoreList:     []string{},
+		resultHasDelta: true,
+	},
+
+}
+
+/*
+ * Since I'm not super familiar with Go, and most of the hasDelta code is
+ * effectively "untyped", I want to make sure my code doesn't fail when
+ * comparing certain type combinations
+ */
+func generateTypeConversionTests() []deltaTestCase {
+	typeValues := MapAny{
+		"string": "foo",
+		"number": 42,
+		"object": MapAny{"foo":"bar"},
+		"array": []string { "foo", "bar" },
+		"bool_true": true,
+		"bool_false": false,
+	}
+
+	tests := make([]deltaTestCase, len(typeValues) * len(typeValues))
+
+	testCounter := 0
+	for fromType, fromValue := range typeValues {
+		for toType, toValue := range typeValues {
+			tests = append(tests, deltaTestCase{
+				testCase:       fmt.Sprintf("Type Conversion from [%s] to [%s]", fromType, toType),
+				testId:         testCounter,
+				o1:             MapAny{"value": fromValue },
+				o2:             MapAny{"value": toValue },
+				ignoreList:     []string{},
+				resultHasDelta: fromType != toType,
+			})
+
+			testCounter += 1
+		}
+	}
+
+	return tests
+}
+
+func TestHasDelta(t *testing.T) {
+	// Run the main test cases
+	for _, testCase := range deltaTestCases {
+		result := hasDelta(testCase.o1, testCase.o2, testCase.ignoreList)
+		if result != testCase.resultHasDelta {
+			t.Errorf("delta_checker_test.go: Test Case [%d:%s] wanted [%v] got [%v]", testCase.testId, testCase.testCase, testCase.resultHasDelta, result)
+		}
+	}
+
+	// Test type changes
+	for _, testCase := range generateTypeConversionTests() {
+		result := hasDelta(testCase.o1, testCase.o2, testCase.ignoreList)
+		if result != testCase.resultHasDelta {
+			t.Errorf("delta_checker_test.go: TYPE CONVERSION Test Case [%d:%s] wanted [%v] got [%v]", testCase.testId, testCase.testCase, testCase.resultHasDelta, result)
+		}
+	}
+
+}

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -298,11 +298,11 @@ func resourceRestAPIRead(d *schema.ResourceData, meta interface{}) error {
 
 			// This checks if there were any changes to the remote resource that will need to be corrected
 			// by comparing the current state with the response returned by the api.
-			hasDifferences := hasDelta(obj.data, obj.apiData, ignoreList)
+			modifiedResource, hasDifferences := getDelta(obj.data, obj.apiData, ignoreList)
 
 			if hasDifferences {
 				log.Printf("resource_api_object.go: Found differences in remote resource\n")
-				encoded, err := json.Marshal(obj.apiData)
+				encoded, err := json.Marshal(modifiedResource)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Hi, @DRuggeri. This PR is to fix issue #81 - provider doesn't refresh state against the remote state.

I've updated the restapi_object resource to now attempt to revert any changes made outside of Terraform.

To support the cases where the API adds metadata out of our control, like "last_modified", you can add those paths to `ignore_changes_to`. For deeply nested paths, you can go "metadata.last_modified".

To get the old behavior back, set `ignore_all_server_changes` to true.

For example, a declaration might look like this:

```terraform
resource "restapi_object" "Linguini" {
  path      = "/api/cats"
  object_id = "Linguini"

  data = jsonencode({
    name    = "Linguini"
    color   = "tabby"
    hobbies = {
      hunting = "birds"
      eating  = "plants"
    }
  })

  ignore_changes_to = [
    "name",
    "last_modified",
    "hobbies.sleeping",
  ]
}
```

Where the response returned by the server:
- removes the name field
- adds the last_modified field
- add the hobbies.sleeping field

Let me know what you think and if you'd like any changes. I don't have a ton of experience in Go, so if anything looks wrong just let me know.