### PR TITLE
Tolerate 200 OK with empty response

### DIFF
--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -319,6 +319,10 @@ func (client *APIClient) sendRequest(method string, path string, data string) (s
 		return body, fmt.Errorf("unexpected response code '%d': %s", resp.StatusCode, body)
 	}
 
+	if body == "" {
+		return "{}", nil
+	}
+
 	return body, nil
 
 }


### PR DESCRIPTION
Fixes #178. 

Background: `restapi` currently tolerates a 200 OK response with `{}` as the body, but it doesn't accept the empty string as the HTTP response body.  This commit changes the behavior for an empty response to match that of `{}`.

In both cases the user would still need to provide the `object_id` explicitly for this to work.

This is a rather common case, as the number of responses to #178 shows. 