### PR TITLE
Fix for endpoint_params #202

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,5 +73,5 @@ Required:
 
 Optional:
 
-- `endpoint_params` (Map of List of String) Additional key/values to pass to the underlying Oauth client library (as EndpointParams)
+- `endpoint_params` (Map of Strings) Additional key/values to pass to the underlying Oauth client library (as EndpointParams). Look in examples/ directory for an example
 - `oauth_scopes` (List of String) scopes

--- a/examples/workingexamples/provider_with_oauth.tf
+++ b/examples/workingexamples/provider_with_oauth.tf
@@ -5,9 +5,14 @@ provider "restapi" {
   write_returns_object = true
 
   oauth_client_credentials {
-      oauth_client_id = "example"
-      oauth_client_secret = "example"
-      oauth_token_endpoint = "https://example.com/tokenendpoint"
-      oauth_scopes = ["openid"]
+    oauth_client_id      = "example"
+    oauth_client_secret  = "example"
+    oauth_token_endpoint = "https://example.com/tokenendpoint"
+    oauth_scopes         = ["openid"]
+    endpoint_params      = <<ENDPOINT_PARAMS
+    {
+      "resource": "http://127.0.0.1/"
+    }
+    ENDPOINT_PARAMS
   }
 }


### PR DESCRIPTION
As of now `endpoint_params` part of `oauth_client_credentials` block isn't functional. Below issues were/are flagged::

- [#202](https://github.com/Mastercard/terraform-provider-restapi/issues/202)
- [#162](https://github.com/Mastercard/terraform-provider-restapi/issues/162)

This PR is a proposal to get it working with the limitations in mind. I disabled the `map` validation for complex values like this one, there is no support & it's discussed [here](https://github.com/hashicorp/terraform-plugin-sdk/issues/62#issuecomment-288364624).  I changed the var type of `endpoint_params` from `map of a list of strings` to `map of strings` as the  go `oauth2` SDK expects in the below format::

```
EndpointParams: url.Values {
    "audience": {"audience1"}
 },
```

To me this is a weird format it's neither `list` nor `string` but `interface{}`. Anyways, with this format being expected, `list` isn't accepted at all. Hence, I chose the `json`. It's partly inspired from [azurerm-provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension.html#settings).

An example configuration would look like below::


```
provider "restapi" {
  uri                  = "https://example.com/"
  debug                = true
  write_returns_object = true

  oauth_client_credentials {
    oauth_client_id      = "xxxx-yyyy-zzzz"
    oauth_client_secret  = "ssshsecret"
    oauth_token_endpoint = "https://login.example.com/abcde/oauth2/token"
    endpoint_params = <<ENDPOINT_PARAMS
    {
      "resource": "https://example.com/"
    }
    ENDPOINT_PARAMS
  }
}
```