### PR TITLE
feat: add support for read_data

### DIFF
--- a/docs/resources/object.md
+++ b/docs/resources/object.md
@@ -40,6 +40,7 @@ resource "restapi_object" "Foo2" {
 - `id_attribute` (String) Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)
 - `object_id` (String) Defaults to the id learned by the provider during normal operations and `id_attribute`. Allows you to set the id manually. This is used in conjunction with the `*_path` attributes.
 - `query_string` (String) Query string to be included in the path
+- `read_data` (String) Valid JSON object to pass during read requests.
 - `read_method` (String) Defaults to `read_method` set on the provider. Allows per-resource override of `read_method` (see `read_method` provider config documentation)
 - `read_path` (String) Defaults to `path/{id}`. The API path that represents where to READ (GET) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
 - `read_search` (Map of String) Custom search for `read_path`. This map will take `search_key`, `search_value`, `results_key` and `query_string` (see datasource config documentation)

--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -30,6 +30,7 @@ type apiClientOpt struct {
 	idAttribute         string
 	createMethod        string
 	readMethod          string
+	readData            string
 	updateMethod        string
 	updateData          string
 	destroyMethod       string
@@ -63,6 +64,7 @@ type APIClient struct {
 	idAttribute         string
 	createMethod        string
 	readMethod          string
+	readData            string
 	updateMethod        string
 	updateData          string
 	destroyMethod       string
@@ -76,7 +78,7 @@ type APIClient struct {
 	oauthConfig         *clientcredentials.Config
 }
 
-//NewAPIClient makes a new api client for RESTful calls
+// NewAPIClient makes a new api client for RESTful calls
 func NewAPIClient(opt *apiClientOpt) (*APIClient, error) {
 	if opt.debug {
 		log.Printf("api_client.go: Constructing debug api_client\n")
@@ -162,6 +164,7 @@ func NewAPIClient(opt *apiClientOpt) (*APIClient, error) {
 		idAttribute:         opt.idAttribute,
 		createMethod:        opt.createMethod,
 		readMethod:          opt.readMethod,
+		readData:            opt.readData,
 		updateMethod:        opt.updateMethod,
 		updateData:          opt.updateData,
 		destroyMethod:       opt.destroyMethod,
@@ -210,8 +213,11 @@ func (client *APIClient) toString() string {
 	return buffer.String()
 }
 
-/* Helper function that handles sending/receiving and handling
-   of HTTP data in and out. */
+/*
+Helper function that handles sending/receiving and handling
+
+	of HTTP data in and out.
+*/
 func (client *APIClient) sendRequest(method string, path string, data string) (string, error) {
 	fullURI := client.uri + path
 	var req *http.Request

--- a/restapi/api_object_test.go
+++ b/restapi/api_object_test.go
@@ -187,6 +187,24 @@ func TestAPIObject(t *testing.T) {
 		}
 	})
 
+	t.Run("read_object_with_read_data", func(t *testing.T) {
+		if testDebug {
+			log.Printf("api_object_test.go: Testing read_object() with read_data")
+		}
+		for testCase := range testingObjects {
+			t.Run(testCase, func(t *testing.T) {
+				if testDebug {
+					log.Printf("api_object_test.go: Getting data for '%s' test case from server\n", testCase)
+				}
+				testingObjects[testCase].readData["path"] = "/" + testCase
+				err := testingObjects[testCase].readObject()
+				if err != nil {
+					t.Fatalf("api_object_test.go: Failed to read data for test case '%s': %s", testCase, err)
+				}
+			})
+		}
+	})
+
 	/* Verify our copy_keys is happy by seeing if Thing made it into the data hash */
 	t.Run("copy_keys", func(t *testing.T) {
 		if testDebug {


### PR DESCRIPTION
Similar to https://github.com/Mastercard/terraform-provider-restapi/pull/182, added support for an argument `read_data` in order to support not-so-RESTful API designs.

Case study is Scalyr/DataSet, whose API for fetching configuration files is implement as a set of POST requests, with the hard requirement that there is a request body (even if it is empty): 

* https://app.scalyr.com/help/api?#getFile (getFile --> requires `path` argument in body)
* https://app.scalyr.com/help/api?#listFile (listFile --> requires empty body)

Tested against this API with some logParser objects, and this helps to support a use case such as:

```hcl
provider "restapi" {
  uri = "https://app.scalyr.com/api"
  headers = {
    "Authorization" = "Bearer ${local.api_token}"
    "Content-Type"  = "application/json"
  }
  debug                = false
  write_returns_object = false
}

resource "restapi_object" "scalyr_parsers" {
  for_each      = local.parsers
  object_id     = "/logParsers/${each.key}"
  path          = "/"
  create_method = "POST"
  update_method = "POST"
  read_method   = "POST"
  read_path     = "/getFile"
  read_data = jsonencode({
    path = "/logParsers/${each.key}"
  })
  create_path = "/putFile"
  data = jsonencode({
    path    = "/logParsers/${each.key}"
    content = each.value
  })
}
```