### PR TITLE
Several improvements for read search

### DIFF
--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -360,6 +360,13 @@ func (obj *APIObject) readObject() error {
 
 	searchKey := obj.readSearch["search_key"]
 	searchValue := obj.readSearch["search_value"]
+	idAttribute := obj.readSearch["id_attribute"]
+	if idAttribute != "" {
+		obj.idAttribute = idAttribute
+		if obj.debug {
+			log.Printf("api_object.go: idAttribute set to '%s'", obj.idAttribute)
+		}
+	}
 
 	if searchKey != "" && searchValue != "" {
 

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -396,6 +396,13 @@ func (obj *APIObject) readObject() error {
 			obj.id = ""
 			return nil
 		}
+		// Strip null values from the object if they are unset in the input data
+		for k, v := range objFound {
+			_, hasKey := obj.data[k]
+			if v == nil && !hasKey {
+				delete(objFound, k)
+			}
+		}
 		objFoundString, _ := json.Marshal(objFound)
 		return obj.updateState(string(objFoundString))
 	}

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -371,6 +371,7 @@ func (obj *APIObject) readObject() error {
 	if searchKey != "" && searchValue != "" {
 
 		obj.searchPath = strings.Replace(obj.getPath, "{id}", obj.id, -1)
+		searchValue = strings.Replace(searchValue, "{id}", obj.id, -1)
 
 		queryString := obj.readSearch["query_string"]
 		if obj.queryString != "" {

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -403,6 +403,13 @@ func (obj *APIObject) readObject() error {
 				delete(objFound, k)
 			}
 		}
+		objectWrap := obj.readSearch["object_wrap"]
+		if objectWrap != "" {
+			if obj.debug {
+				log.Printf("api_object.go: Wrapping object in '%s'", objectWrap)
+			}
+			objFound = map[string]interface{}{objectWrap: objFound}
+		}
 		objFoundString, _ := json.Marshal(objFound)
 		return obj.updateState(string(objFoundString))
 	}

--- a/restapi/delta_checker.go
+++ b/restapi/delta_checker.go
@@ -100,7 +100,9 @@ func _descendIgnoreList(descendPath string, ignoreList []string) []string {
 	newIgnoreList := make([]string, len(ignoreList))
 
 	for _, ignorePath := range ignoreList {
-		pathComponents := strings.Split(ignorePath, ".")
+		pathComponents := strings.FieldsFunc(ignorePath, func(r rune) bool {
+			return r == '.' || r == '/'
+		})
 		// If this ignorePath starts with the descendPath, remove the first component and keep the rest
 		if pathComponents[0] == descendPath {
 			modifiedPath := strings.Join(pathComponents[1:], ".")


### PR DESCRIPTION
This PR includes 3 features in read_search, and 2 other changes, which are required for supporting voxbone api.

read_search features:
* Support id_attribute
* Support {id} substitution also for search_value in read_search
* Support object_wrap

Other changes:
* Support slash separator for ignore_changes_to
* Strip null values when comparing read output if they're not set in the input.


Some providers use a different notation for the object on create/update and on read.

Full example for Voxbone voiceuri api follows.

Sample PUT request:

PUT /configuration/voiceuri

Data:
```json
{
  "voiceUri": {
    "voiceUriProtocol": "SIP",
    "uri": "num@server.com",
    "description": "desc"
  }
}
```

Response is the same, but with voiceUriId in voiceUri.

GET sample:

GET /configuration/voiceuri/1234
```json
{
  "voiceUris": [
    {
      "voiceUriId": 1234,
      "backupUriId": null,
      "backupUri": null,
      "voiceUriProtocol": "SIP",
      "uri": "num@server.com",
      "description": "desc"
    }
  ],
  "resultCount": 1
}
```

Notice that read doesn't have an internal voiceUri in voiceUris array.

Sample provider configuration:
```tf
provider "restapi" {
  uri                   = "https://api.voxbone.com/v1"
  create_method         = "PUT"
  update_method         = "PUT"
  create_returns_object = true
  write_returns_object  = true
}

resource "restapi_object" "voxbone_voice_uri" {
  path         = "/configuration/voiceuri"
  id_attribute = "voiceUri/voiceUriId"
  ignore_changes_to = ["voiceUri/voiceUriId"]

  read_search = {
    results_key = "voiceUris"
    search_key  = "voiceUriId"
    search_value = "{id}"
    id_attribute = "voiceUriId"
    object_wrap = "voiceUri"
  }

  data = jsonencode({
    voiceUri = {
      uri              = "num@server.com"
      voiceUriProtocol = "SIP"
      description      = "desc"
    }
  })
}
```
