### PR TITLE
added support for ok status codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist
 .idea
 .terraform.lock.hcl
 dev.tfrc
+terraform-provider-restapi_*

--- a/docs/resources/object.md
+++ b/docs/resources/object.md
@@ -40,6 +40,7 @@ resource "restapi_object" "Foo2" {
 - `id_attribute` (String) Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)
 - `ignore_all_server_changes` (Boolean) By default Terraform will attempt to revert changes to remote resources. Set this to 'true' to ignore any remote changes. Default: false
 - `ignore_changes_to` (List of String) A list of fields to which remote changes will be ignored. For example, an API might add or remove metadata, such as a 'last_modified' field, which Terraform should not attempt to correct. To ignore changes to nested fields, use the dot syntax: 'metadata.timestamp'
+- `ok_status_codes` (String) List/range of acceptable status codes (e.g., `"200-299"`, `"200,201,404"`, `"200-299,404"`). Overrides the provider-level setting. If not set, defaults to the provider setting (or 2xx if the provider is not set). If set to an empty string `""`, defaults to status codes 200-399.
 - `object_id` (String) Defaults to the id learned by the provider during normal operations and `id_attribute`. Allows you to set the id manually. This is used in conjunction with the `*_path` attributes.
 - `query_string` (String) Query string to be included in the path
 - `read_data` (String) Valid JSON object to pass during read requests.


### PR DESCRIPTION
## Feature: Configurable Success Status Codes

This PR introduces the ability to configure the range of HTTP status codes that are considered successful for API responses, enhancing the provider's flexibility while maintaining backward compatibility.

**Problem:**

Previously, the provider hardcoded successful responses as only those with status codes in the 2xx range (200-299). This could cause Terraform plans to fail unnecessarily for APIs that use other status codes (e.g., 404, or custom success codes) as standard success indicators.

**Solution:**

1.  **New `ok_status_codes` Attribute:**
    *   A new optional attribute `ok_status_codes` of type `String` has been added to both the `provider` configuration block and the `restapi_object` resource.
    *   This allows setting acceptable status codes globally via the provider or overriding them on a per-resource basis.

2.  **Flexible String Format:**
    *   The `ok_status_codes` attribute accepts a string defining the acceptable codes using:
        *   Single codes: `"200"`
        *   Comma-separated lists: `"200,201,204"`
        *   Ranges: `"200-299"`
        *   Mixed formats: `"200-299,404,201"`

3.  **Behavior:**
    *   **Backward Compatibility:** If `ok_status_codes` is **not configured** at either the provider or resource level, the provider retains its original behavior, considering only **2xx (200-299)** status codes as successful.
    *   **Empty String (`""`):** If `ok_status_codes` is explicitly set to an empty string (`ok_status_codes = ""`), it signifies that the user wants the standard success range, and the provider will accept codes **200-399**.
    *   **Specific Codes/Ranges:** If `ok_status_codes` is set to a non-empty string (e.g., `"201,204"` or `"200-204,404"`), the provider will *only* consider the specifically listed/ranged codes as successful. Any other code will result in an error.
    *   **Override:** The resource-level `ok_status_codes` completely overrides the provider-level setting if both are defined.

**Implementation Details:**

*   Modified `api_client.go` to handle the status code checking based on the configured `okStatusCodes` slice (`nil` for default 2xx, empty slice for 200-399, non-empty slice for specific checks).
*   Added parsing logic (`parseStatusCodesString`) in `provider.go` to handle the flexible string format.
*   Updated `provider.go` and `resource_api_object.go` schemas and configuration logic to read and parse the new attribute.
*   Added documentation for `ok_status_codes` to `docs/resources/object.md`.

This change allows users to tailor the provider's behavior to APIs with non-standard success code conventions without breaking existing configurations.
