### PR TITLE
Feat/bearer_token_support

### DIFF
--- a/restapi/api_client.go
+++ b/restapi/api_client.go
@@ -28,6 +28,7 @@ type apiClientOpt struct {
 	username            string
 	password            string
 	headers             map[string]string
+	bearer_token        string
 	timeout             int
 	idAttribute         string
 	createMethod        string
@@ -65,6 +66,7 @@ type APIClient struct {
 	username            string
 	password            string
 	headers             map[string]string
+	bearer_token        string
 	idAttribute         string
 	createMethod        string
 	readMethod          string
@@ -190,6 +192,7 @@ func NewAPIClient(opt *apiClientOpt) (*APIClient, error) {
 		username:            opt.username,
 		password:            opt.password,
 		headers:             opt.headers,
+		bearer_token:        opt.bearer_token,
 		idAttribute:         opt.idAttribute,
 		createMethod:        opt.createMethod,
 		readMethod:          opt.readMethod,

--- a/restapi/provider.go
+++ b/restapi/provider.go
@@ -43,6 +43,13 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: "A map of header names and values to set on all outbound requests. This is useful if you want to use a script via the 'external' provider or provide a pre-approved token or change Content-Type from `application/json`. If `username` and `password` are set and Authorization is one of the headers defined here, the BASIC auth credentials take precedence.",
 			},
+			"bearer_token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("BEARER_TOKEN", nil),
+				Description: "Token to use for Authorization: Bearer <token>",
+			},
 			"use_cookies": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -234,6 +241,10 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		for k, v := range iHeaders.(map[string]interface{}) {
 			headers[k] = v.(string)
 		}
+	}
+
+	if token, ok := d.GetOk("bearer_token"); ok && token.(string) != "" {
+		headers["Authorization"] = "Bearer " + token.(string)
 	}
 
 	opt := &apiClientOpt{

--- a/restapi/provider.go
+++ b/restapi/provider.go
@@ -33,6 +33,7 @@ func Provider() *schema.Provider {
 			"password": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("REST_API_PASSWORD", nil),
 				Description: "When set, will use this password for BASIC auth to the API.",
 			},


### PR DESCRIPTION
### Summary

This PR introduces a new `bearer_token` parameter in the provider configuration to support injecting an `Authorization: Bearer <token>` header automatically.

- The token can be passed via the provider block or via the `BEARER_TOKEN` environment variable
- Useful for APIs requiring JWT or OAuth2 bearer-style authentication
- Preserves backward compatibility
- Also marks `password` as sensitive to prevent accidental exposure

Includes a unit test to validate header injection.

Let me know if you’d like this change split into two separate PRs.
