### PR TITLE
Add `read_object_key` to Handle Wrapped API ResponsesFeature/read object key

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This provider has only a few moving components, but LOTS of configurable paramet
 * By default, data isn't considered sensitive. If you want to hide the data this provider submits as well as the data returned by the API, you would need to set environment variable `API_DATA_IS_SENSITIVE=true`.
 * The `*_path` elements are for very specific use cases where one might initially create an object in one location, but read/update/delete it on another path. For this reason, they allow for substitution to be done by the provider internally by injecting the `id` somewhere along the path. This is similar to terraform's substitution syntax in the form of `${variable.name}`, but must be done within the provider due to structure. The only substitution available is to replace the string `{id}` with the internal (terraform) `id` of the object as learned by the `id_attribute`.
   * NOTICE: read operations performed on existing objects are done against the `read_path` **stored in state** rather than the new configuration!
+* If your API wraps GET responses in an envelope (e.g., `{"result": {...}}`), use `read_object_key` to extract the actual object before state comparison. This prevents false drift when the wrapper structure differs from POST/PUT requests. Supports nested paths like `"data/items"` or `"response/resource"`. Can be set at provider level or per-resource.
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This provider has only a few moving components, but LOTS of configurable paramet
 * The `*_path` elements are for very specific use cases where one might initially create an object in one location, but read/update/delete it on another path. For this reason, they allow for substitution to be done by the provider internally by injecting the `id` somewhere along the path. This is similar to terraform's substitution syntax in the form of `${variable.name}`, but must be done within the provider due to structure. The only substitution available is to replace the string `{id}` with the internal (terraform) `id` of the object as learned by the `id_attribute`.
   * NOTICE: read operations performed on existing objects are done against the `read_path` **stored in state** rather than the new configuration!
 * If your API wraps GET responses in an envelope (e.g., `{"result": {...}}`), use `read_object_key` to extract the actual object before state comparison. This prevents false drift when the wrapper structure differs from POST/PUT requests. Supports nested paths like `"data/items"` or `"response/resource"`. Can be set at provider level or per-resource.
+* If your API requires POST/PUT request bodies to be wrapped in an envelope (e.g., `{"entry": {...}}`), use `write_object_key` to automatically wrap the data before sending. Supports nested paths like `"request/data"`. Can be set at provider level or per-resource. Both `read_object_key` and `write_object_key` can be used together for APIs that wrap in both directions.
 
 &nbsp;
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -16,4 +16,9 @@ provider "restapi" {
   # Use this if your API returns responses like: {"result": {...}, "success": true}
   # Supports nested paths: "data/items", "response/resource"
   # read_object_key = "result"
+
+  # Optional: Wrap POST/PUT request bodies in an envelope
+  # Use this if your API requires data nested like: {"entry": {...}}
+  # Supports nested paths: "request/data"
+  # write_object_key = "entry"
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -11,4 +11,9 @@ provider "restapi" {
   create_method  = "PUT"
   update_method  = "PUT"
   destroy_method = "PUT"
+
+  # Optional: Extract objects from wrapped GET responses
+  # Use this if your API returns responses like: {"result": {...}, "success": true}
+  # Supports nested paths: "data/items", "response/resource"
+  # read_object_key = "result"
 }

--- a/examples/resources/restapi_object/resource_with_wrapped_response.tf
+++ b/examples/resources/restapi_object/resource_with_wrapped_response.tf
@@ -60,3 +60,34 @@ resource "restapi_object" "overrides_provider" {
     name = "resource-two"
   })
 }
+
+# Example: API that requires wrapped POST/PUT request bodies
+# API expects: POST {"entry": {"name": "foo", "config": {...}}}
+# API returns: GET {"name": "foo", "config": {...}} (flat, no wrapper)
+resource "restapi_object" "example_wrapped_write" {
+  path = "/api/entries"
+
+  # Wrap POST/PUT body under "entry" key before sending
+  write_object_key = "entry"
+
+  data = jsonencode({
+    name   = "my-resource"
+    config = {
+      setting = "value"
+    }
+  })
+}
+
+# Example: Both directions - wrapped reads AND wrapped writes
+# POST must send: {"request": {"name": "foo"}}
+# GET returns: {"response": {"name": "foo"}, "status": "ok"}
+resource "restapi_object" "example_both_wrapped" {
+  path = "/api/bidirectional"
+
+  write_object_key = "request"
+  read_object_key  = "response"
+
+  data = jsonencode({
+    name = "bidirectional-resource"
+  })
+}

--- a/examples/resources/restapi_object/resource_with_wrapped_response.tf
+++ b/examples/resources/restapi_object/resource_with_wrapped_response.tf
@@ -1,0 +1,62 @@
+# Example: API that wraps GET responses in an envelope structure
+# POST/PUT sends: {"name": "foo", "config": {...}}
+# GET returns: {"result": {"name": "foo", "config": {...}}, "success": true}
+#
+# Without read_object_key, this causes false drift because the provider
+# compares the wrapped response to the unwrapped request data.
+
+resource "restapi_object" "example_wrapped" {
+  path = "/api/objects"
+
+  # Extract the actual object from the "result" wrapper before state storage
+  read_object_key = "result"
+
+  data = jsonencode({
+    name   = "my-resource"
+    config = {
+      setting = "value"
+    }
+  })
+}
+
+# Example: Nested wrapper path
+# GET returns: {"response": {"data": {"id": "123", "value": "bar"}}, "meta": {...}}
+resource "restapi_object" "example_nested" {
+  path = "/api/objects"
+
+  # Use slash-delimited path to extract from nested structure
+  read_object_key = "response/data"
+
+  data = jsonencode({
+    id    = "123"
+    value = "bar"
+  })
+}
+
+# Example: Provider-level default with resource override
+provider "restapi" {
+  uri = "https://api.example.com"
+
+  # Set default extraction key for all resources
+  read_object_key = "result"
+}
+
+resource "restapi_object" "uses_provider_default" {
+  path = "/api/objects"
+  # This resource will use "result" from provider config
+
+  data = jsonencode({
+    name = "resource-one"
+  })
+}
+
+resource "restapi_object" "overrides_provider" {
+  path = "/api/other"
+
+  # Override provider-level setting for this specific resource
+  read_object_key = "data"
+
+  data = jsonencode({
+    name = "resource-two"
+  })
+}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -36,6 +36,7 @@ type APIClientOpt struct {
 	CreateMethod        string
 	ReadMethod          string
 	ReadData            string
+	ReadObjectKey       string
 	UpdateMethod        string
 	UpdateData          string
 	DestroyMethod       string
@@ -75,6 +76,7 @@ type APIClient struct {
 	createMethod        string
 	readMethod          string
 	readData            string
+	readObjectKey       string
 	updateMethod        string
 	updateData          string
 	destroyMethod       string
@@ -225,6 +227,7 @@ func NewAPIClient(opt *APIClientOpt) (*APIClient, error) {
 		createMethod:        opt.CreateMethod,
 		readMethod:          opt.ReadMethod,
 		readData:            opt.ReadData,
+		readObjectKey:       opt.ReadObjectKey,
 		updateMethod:        opt.UpdateMethod,
 		updateData:          opt.UpdateData,
 		destroyMethod:       opt.DestroyMethod,

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -37,6 +37,7 @@ type APIClientOpt struct {
 	ReadMethod          string
 	ReadData            string
 	ReadObjectKey       string
+	WriteObjectKey      string
 	UpdateMethod        string
 	UpdateData          string
 	DestroyMethod       string
@@ -77,6 +78,7 @@ type APIClient struct {
 	readMethod          string
 	readData            string
 	readObjectKey       string
+	writeObjectKey      string
 	updateMethod        string
 	updateData          string
 	destroyMethod       string
@@ -228,6 +230,7 @@ func NewAPIClient(opt *APIClientOpt) (*APIClient, error) {
 		readMethod:          opt.ReadMethod,
 		readData:            opt.ReadData,
 		readObjectKey:       opt.ReadObjectKey,
+		writeObjectKey:      opt.WriteObjectKey,
 		updateMethod:        opt.UpdateMethod,
 		updateData:          opt.UpdateData,
 		destroyMethod:       opt.DestroyMethod,

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -22,6 +22,7 @@ type APIObjectOpts struct {
 	ReadMethod    string
 	ReadPath      string
 	ReadData      string
+	ReadObjectKey string
 	UpdateMethod  string
 	UpdatePath    string
 	UpdateData    string
@@ -44,6 +45,7 @@ type APIObject struct {
 	createPath    string
 	readMethod    string
 	readPath      string
+	readObjectKey string
 	updateMethod  string
 	updatePath    string
 	destroyMethod string
@@ -88,6 +90,10 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 	if opts.ReadData == "" {
 		opts.ReadData = iClient.readData
 	}
+	// read_object_key can be set either on the client or per-object basis
+	if opts.ReadObjectKey == "" {
+		opts.ReadObjectKey = iClient.readObjectKey
+	}
 	if opts.UpdateMethod == "" {
 		opts.UpdateMethod = iClient.updateMethod
 	}
@@ -130,6 +136,7 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 		queryString:   opts.QueryString,
 		debug:         opts.Debug,
 		readSearch:    opts.ReadSearch,
+		readObjectKey: opts.ReadObjectKey,
 		ID:            opts.ID,
 		IDAttribute:   opts.IDAttribute,
 		data:          make(map[string]interface{}),
@@ -419,6 +426,35 @@ func (obj *APIObject) ReadObject(ctx context.Context) error {
 		return err
 	}
 
+	// Extract wrapped response if read_object_key is configured (backward compatible: empty string = no extraction)
+	if obj.readObjectKey != "" {
+		tflog.Debug(ctx, "Extracting object from response",
+			map[string]interface{}{"read_object_key": obj.readObjectKey})
+
+		var result interface{}
+		err = json.Unmarshal([]byte(resultString), &result)
+		if err != nil {
+			return fmt.Errorf("failed to parse response for read_object_key extraction: %w", err)
+		}
+
+		resultMap, ok := result.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("response is not a JSON object, cannot extract read_object_key '%s'", obj.readObjectKey)
+		}
+
+		extracted, err := GetObjectAtKey(ctx, resultMap, obj.readObjectKey)
+		if err != nil {
+			return fmt.Errorf("failed to extract read_object_key '%s': %w", obj.readObjectKey, err)
+		}
+
+		extractedJSON, err := json.Marshal(extracted)
+		if err != nil {
+			return fmt.Errorf("failed to marshal extracted object: %w", err)
+		}
+		resultString = string(extractedJSON)
+		tflog.Debug(ctx, "Successfully extracted object", map[string]interface{}{"read_object_key": obj.readObjectKey})
+	}
+
 	return obj.updateInternalState(resultString)
 }
 
@@ -601,6 +637,11 @@ func (obj *APIObject) GetApiData() map[string]string {
 // GetApiResponse returns a copy of the raw API response from the APIObject
 func (obj *APIObject) GetApiResponse() string {
 	return obj.apiResponse
+}
+
+// GetReadObjectKey returns the read_object_key configuration value
+func (obj *APIObject) GetReadObjectKey() string {
+	return obj.readObjectKey
 }
 
 // GetReadSearch returns a copy of the read_search configuration

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -16,46 +16,48 @@ import (
 )
 
 type APIObjectOpts struct {
-	Path          string
-	CreatePath    string
-	CreateMethod  string
-	ReadMethod    string
-	ReadPath      string
-	ReadData      string
-	ReadObjectKey string
-	UpdateMethod  string
-	UpdatePath    string
-	UpdateData    string
-	DestroyMethod string
-	DestroyData   string
-	DestroyPath   string
-	SearchPath    string
-	QueryString   string
-	Debug         bool
-	ReadSearch    map[string]string
-	ID            string
-	IDAttribute   string
-	Data          string
+	Path           string
+	CreatePath     string
+	CreateMethod   string
+	ReadMethod     string
+	ReadPath       string
+	ReadData       string
+	ReadObjectKey  string
+	WriteObjectKey string
+	UpdateMethod   string
+	UpdatePath     string
+	UpdateData     string
+	DestroyMethod  string
+	DestroyData    string
+	DestroyPath    string
+	SearchPath     string
+	QueryString    string
+	Debug          bool
+	ReadSearch     map[string]string
+	ID             string
+	IDAttribute    string
+	Data           string
 }
 
 // APIObject is the state holding struct for a restapi_object resource
 type APIObject struct {
-	apiClient     *APIClient
-	createMethod  string
-	createPath    string
-	readMethod    string
-	readPath      string
-	readObjectKey string
-	updateMethod  string
-	updatePath    string
-	destroyMethod string
-	deletePath    string
-	searchPath    string
-	queryString   string
-	debug         bool
-	readSearch    map[string]string
-	ID            string
-	IDAttribute   string
+	apiClient      *APIClient
+	createMethod   string
+	createPath     string
+	readMethod     string
+	readPath       string
+	readObjectKey  string
+	writeObjectKey string
+	updateMethod   string
+	updatePath     string
+	destroyMethod  string
+	deletePath     string
+	searchPath     string
+	queryString    string
+	debug          bool
+	readSearch     map[string]string
+	ID             string
+	IDAttribute    string
 
 	// Set internally
 	mux         sync.RWMutex           // Protects data and apiData fields
@@ -94,6 +96,10 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 	if opts.ReadObjectKey == "" {
 		opts.ReadObjectKey = iClient.readObjectKey
 	}
+	// write_object_key can be set either on the client or per-object basis
+	if opts.WriteObjectKey == "" {
+		opts.WriteObjectKey = iClient.writeObjectKey
+	}
 	if opts.UpdateMethod == "" {
 		opts.UpdateMethod = iClient.updateMethod
 	}
@@ -123,27 +129,28 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 	}
 
 	obj := APIObject{
-		apiClient:     iClient,
-		readPath:      opts.ReadPath,
-		createPath:    opts.CreatePath,
-		updatePath:    opts.UpdatePath,
-		createMethod:  opts.CreateMethod,
-		readMethod:    opts.ReadMethod,
-		updateMethod:  opts.UpdateMethod,
-		destroyMethod: opts.DestroyMethod,
-		deletePath:    opts.DestroyPath,
-		searchPath:    opts.SearchPath,
-		queryString:   opts.QueryString,
-		debug:         opts.Debug,
-		readSearch:    opts.ReadSearch,
-		readObjectKey: opts.ReadObjectKey,
-		ID:            opts.ID,
-		IDAttribute:   opts.IDAttribute,
-		data:          make(map[string]interface{}),
-		readData:      nil,
-		updateData:    nil,
-		destroyData:   nil,
-		apiData:       make(map[string]interface{}),
+		apiClient:      iClient,
+		readPath:       opts.ReadPath,
+		createPath:     opts.CreatePath,
+		updatePath:     opts.UpdatePath,
+		createMethod:   opts.CreateMethod,
+		readMethod:     opts.ReadMethod,
+		updateMethod:   opts.UpdateMethod,
+		destroyMethod:  opts.DestroyMethod,
+		deletePath:     opts.DestroyPath,
+		searchPath:     opts.SearchPath,
+		queryString:    opts.QueryString,
+		debug:          opts.Debug,
+		readSearch:     opts.ReadSearch,
+		readObjectKey:  opts.ReadObjectKey,
+		writeObjectKey: opts.WriteObjectKey,
+		ID:             opts.ID,
+		IDAttribute:    opts.IDAttribute,
+		data:           make(map[string]interface{}),
+		readData:       nil,
+		updateData:     nil,
+		destroyData:    nil,
+		apiData:        make(map[string]interface{}),
 	}
 
 	if opts.Data != "" {
@@ -305,13 +312,20 @@ func (obj *APIObject) CreateObject(ctx context.Context) error {
 	b, _ := json.Marshal(obj.data)
 	obj.mux.RUnlock()
 
+	send := string(b)
+	// Wrap request body if write_object_key is configured
+	send, err := obj.wrapRequestBody(ctx, send)
+	if err != nil {
+		return err
+	}
+
 	postPath := obj.createPath
 	if obj.queryString != "" {
 		tflog.Debug(ctx, "Adding query string", map[string]interface{}{"query_string": obj.queryString})
 		postPath = fmt.Sprintf("%s?%s", obj.createPath, obj.queryString)
 	}
 
-	resultString, _, err := obj.apiClient.SendRequest(ctx, obj.createMethod, strings.Replace(postPath, "{id}", obj.ID, -1), string(b), obj.debug)
+	resultString, _, err := obj.apiClient.SendRequest(ctx, obj.createMethod, strings.Replace(postPath, "{id}", obj.ID, -1), send, obj.debug)
 	if err != nil {
 		return err
 	}
@@ -476,6 +490,12 @@ func (obj *APIObject) UpdateObject(ctx context.Context) error {
 		send = string(b)
 	}
 	obj.mux.RUnlock()
+
+	// Wrap request body if write_object_key is configured
+	send, err := obj.wrapRequestBody(ctx, send)
+	if err != nil {
+		return err
+	}
 
 	putPath := obj.updatePath
 	if obj.queryString != "" {
@@ -642,6 +662,47 @@ func (obj *APIObject) GetApiResponse() string {
 // GetReadObjectKey returns the read_object_key configuration value
 func (obj *APIObject) GetReadObjectKey() string {
 	return obj.readObjectKey
+}
+
+// GetWriteObjectKey returns the write_object_key configuration value
+func (obj *APIObject) GetWriteObjectKey() string {
+	return obj.writeObjectKey
+}
+
+// wrapRequestBody wraps a JSON string under write_object_key if configured.
+// For example, with write_object_key="entry" and data=`{"id":"1","name":"foo"}`,
+// returns `{"entry":{"id":"1","name":"foo"}}`.
+// Supports nested paths with '/' delimiter (e.g., "request/data").
+func (obj *APIObject) wrapRequestBody(ctx context.Context, data string) (string, error) {
+	if obj.writeObjectKey == "" {
+		return data, nil
+	}
+
+	tflog.Debug(ctx, "Wrapping request body", map[string]interface{}{"write_object_key": obj.writeObjectKey})
+
+	// Parse the original data
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(data), &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse data for write_object_key wrapping: %w", err)
+	}
+
+	// Build nested wrapper from path segments (e.g., "request/data" → {"request": {"data": ...}})
+	parts := strings.Split(obj.writeObjectKey, "/")
+	wrapped := parsed
+	for i := len(parts) - 1; i >= 0; i-- {
+		if parts[i] == "" {
+			continue
+		}
+		wrapped = map[string]interface{}{parts[i]: wrapped}
+	}
+
+	result, err := json.Marshal(wrapped)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal wrapped data: %w", err)
+	}
+
+	tflog.Debug(ctx, "Successfully wrapped request body", map[string]interface{}{"write_object_key": obj.writeObjectKey})
+	return string(result), nil
 }
 
 // GetReadSearch returns a copy of the read_search configuration

--- a/internal/apiclient/object_read_objectkey_test.go
+++ b/internal/apiclient/object_read_objectkey_test.go
@@ -1,0 +1,223 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestReadObject_ReadObjectKey tests the read_object_key extraction feature
+func TestReadObject_ReadObjectKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		readObjectKey  string
+		apiResponse    map[string]interface{}
+		expectedData   map[string]interface{}
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:          "simple_wrapper_extraction",
+			readObjectKey: "result",
+			apiResponse: map[string]interface{}{
+				"result": map[string]interface{}{
+					"id":   "test-123",
+					"name": "test-object",
+				},
+			},
+			expectedData: map[string]interface{}{
+				"id":   "test-123",
+				"name": "test-object",
+			},
+			expectError: false,
+		},
+		{
+			name:          "nested_path_extraction",
+			readObjectKey: "data/item",
+			apiResponse: map[string]interface{}{
+				"data": map[string]interface{}{
+					"item": map[string]interface{}{
+						"id":    "nested-456",
+						"value": "nested-data",
+					},
+				},
+			},
+			expectedData: map[string]interface{}{
+				"id":    "nested-456",
+				"value": "nested-data",
+			},
+			expectError: false,
+		},
+		{
+			name:          "no_extraction_empty_key",
+			readObjectKey: "",
+			apiResponse: map[string]interface{}{
+				"id":   "direct-789",
+				"name": "direct-object",
+			},
+			expectedData: map[string]interface{}{
+				"id":   "direct-789",
+				"name": "direct-object",
+			},
+			expectError: false,
+		},
+		{
+			name:          "error_key_not_found",
+			readObjectKey: "missing_key",
+			apiResponse: map[string]interface{}{
+				"result": map[string]interface{}{
+					"id": "test-123",
+				},
+			},
+			expectedData:  nil,
+			expectError:   true,
+			errorContains: "failed to extract read_object_key 'missing_key'",
+		},
+		{
+			name:          "deep_nested_path",
+			readObjectKey: "response/data/items",
+			apiResponse: map[string]interface{}{
+				"response": map[string]interface{}{
+					"data": map[string]interface{}{
+						"items": map[string]interface{}{
+							"id":   "deep-999",
+							"type": "nested",
+						},
+					},
+				},
+			},
+			expectedData: map[string]interface{}{
+				"id":   "deep-999",
+				"type": "nested",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(tt.apiResponse)
+			}))
+			defer server.Close()
+
+			// Create API client
+			client, err := NewAPIClient(&APIClientOpt{
+				URI:     server.URL,
+				Timeout: 2,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create API client: %v", err)
+			}
+
+			// Create API object with read_object_key
+			obj, err := NewAPIObject(client, &APIObjectOpts{
+				Path:          "/api/objects",
+				ReadObjectKey: tt.readObjectKey,
+				ID:            "test-id",
+				Data:          `{"id": "test-id"}`,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create API object: %v", err)
+			}
+
+			// Execute ReadObject
+			err = obj.ReadObject(context.Background())
+
+			// Verify error expectations
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("Expected error but got none")
+				}
+				if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
+					t.Fatalf("Expected error to contain '%s', got: %v", tt.errorContains, err)
+				}
+				return
+			}
+
+			// Verify no error
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Verify extracted data matches expected
+			actualData := obj.GetApiData()
+			if tt.expectedData != nil {
+				for k, expectedValue := range tt.expectedData {
+					actualValue, exists := actualData[k]
+					if !exists {
+						t.Errorf("Expected key '%s' not found in api_data", k)
+					} else if actualValue != expectedValue {
+						t.Errorf("Key '%s': expected '%v', got '%v'", k, expectedValue, actualValue)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestReadObject_ReadObjectKeyWithXSSIPrefix tests that both xssi_prefix and read_object_key work together
+func TestReadObject_ReadObjectKeyWithXSSIPrefix(t *testing.T) {
+	// Create test server that returns XSSI-prefixed wrapped response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// XSSI prefix + wrapped response
+		w.Write([]byte(")]}'\n{\"data\": {\"id\": \"xssi-123\", \"value\": \"protected\"}}"))
+	}))
+	defer server.Close()
+
+	// Create API client with XSSI prefix configured
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:        server.URL,
+		Timeout:    2,
+		XSSIPrefix: ")]}'\n",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	// Create API object with read_object_key
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:          "/api/objects",
+		ReadObjectKey: "data", // Should extract after XSSI strip
+		ID:            "xssi-123",
+		Data:          `{"id": "xssi-123"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	// Execute ReadObject
+	err = obj.ReadObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify extracted data (not wrapped, XSSI stripped)
+	apiData := obj.GetApiData()
+	if apiData["id"] != "xssi-123" {
+		t.Errorf("Expected id 'xssi-123', got: %v", apiData["id"])
+	}
+	if apiData["value"] != "protected" {
+		t.Errorf("Expected value 'protected', got: %v", apiData["value"])
+	}
+}
+
+// Helper function for string contains check
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && indexOf(s, substr) >= 0))
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/apiclient/object_read_objectkey_test.go
+++ b/internal/apiclient/object_read_objectkey_test.go
@@ -11,12 +11,12 @@ import (
 // TestReadObject_ReadObjectKey tests the read_object_key extraction feature
 func TestReadObject_ReadObjectKey(t *testing.T) {
 	tests := []struct {
-		name           string
-		readObjectKey  string
-		apiResponse    map[string]interface{}
-		expectedData   map[string]interface{}
-		expectError    bool
-		errorContains  string
+		name          string
+		readObjectKey string
+		apiResponse   map[string]interface{}
+		expectedData  map[string]interface{}
+		expectError   bool
+		errorContains string
 	}{
 		{
 			name:          "simple_wrapper_extraction",

--- a/internal/apiclient/object_write_objectkey_test.go
+++ b/internal/apiclient/object_write_objectkey_test.go
@@ -1,0 +1,361 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestCreateObject_WriteObjectKey tests that write_object_key wraps POST request bodies
+func TestCreateObject_WriteObjectKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		writeObjectKey string
+		data           string
+		expectedBody   map[string]interface{}
+	}{
+		{
+			name:           "simple_wrapping",
+			writeObjectKey: "entry",
+			data:           `{"id": "test-1", "name": "foo"}`,
+			expectedBody: map[string]interface{}{
+				"entry": map[string]interface{}{
+					"id":   "test-1",
+					"name": "foo",
+				},
+			},
+		},
+		{
+			name:           "nested_wrapping",
+			writeObjectKey: "request/data",
+			data:           `{"id": "test-2", "value": "bar"}`,
+			expectedBody: map[string]interface{}{
+				"request": map[string]interface{}{
+					"data": map[string]interface{}{
+						"id":    "test-2",
+						"value": "bar",
+					},
+				},
+			},
+		},
+		{
+			name:           "no_wrapping_empty_key",
+			writeObjectKey: "",
+			data:           `{"id": "test-3", "name": "baz"}`,
+			expectedBody: map[string]interface{}{
+				"id":   "test-3",
+				"name": "baz",
+			},
+		},
+		{
+			name:           "deep_nested_wrapping",
+			writeObjectKey: "api/v2/payload",
+			data:           `{"id": "test-4", "config": {"enabled": true}}`,
+			expectedBody: map[string]interface{}{
+				"api": map[string]interface{}{
+					"v2": map[string]interface{}{
+						"payload": map[string]interface{}{
+							"id": "test-4",
+							"config": map[string]interface{}{
+								"enabled": true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var receivedBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "POST" {
+					body, _ := io.ReadAll(r.Body)
+					json.Unmarshal(body, &receivedBody)
+				}
+				// Return the unwrapped object (as if API strips the wrapper)
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":   "test-1",
+					"name": "foo",
+				})
+			}))
+			defer server.Close()
+
+			client, err := NewAPIClient(&APIClientOpt{
+				URI:                server.URL,
+				Timeout:            2,
+				WriteReturnsObject: true,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create API client: %v", err)
+			}
+
+			obj, err := NewAPIObject(client, &APIObjectOpts{
+				Path:           "/api/objects",
+				WriteObjectKey: tt.writeObjectKey,
+				Data:           tt.data,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create API object: %v", err)
+			}
+
+			err = obj.CreateObject(context.Background())
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Verify the request body was wrapped correctly
+			expectedJSON, _ := json.Marshal(tt.expectedBody)
+			receivedJSON, _ := json.Marshal(receivedBody)
+
+			var expectedNorm, receivedNorm interface{}
+			json.Unmarshal(expectedJSON, &expectedNorm)
+			json.Unmarshal(receivedJSON, &receivedNorm)
+
+			expectedStr, _ := json.Marshal(expectedNorm)
+			receivedStr, _ := json.Marshal(receivedNorm)
+
+			if string(expectedStr) != string(receivedStr) {
+				t.Errorf("Request body mismatch.\nExpected: %s\nReceived: %s", string(expectedStr), string(receivedStr))
+			}
+		})
+	}
+}
+
+// TestUpdateObject_WriteObjectKey tests that write_object_key wraps PUT request bodies
+func TestUpdateObject_WriteObjectKey(t *testing.T) {
+	var receivedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":   "update-1",
+			"name": "updated",
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:                server.URL,
+		Timeout:            2,
+		WriteReturnsObject: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/api/objects",
+		WriteObjectKey: "entry",
+		ID:             "update-1",
+		Data:           `{"id": "update-1", "name": "updated"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	err = obj.UpdateObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify the PUT body was wrapped under "entry"
+	entry, ok := receivedBody["entry"]
+	if !ok {
+		t.Fatalf("Expected request body to have 'entry' key, got: %v", receivedBody)
+	}
+	entryMap, ok := entry.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected 'entry' to be a map, got: %T", entry)
+	}
+	if entryMap["id"] != "update-1" {
+		t.Errorf("Expected id 'update-1', got: %v", entryMap["id"])
+	}
+	if entryMap["name"] != "updated" {
+		t.Errorf("Expected name 'updated', got: %v", entryMap["name"])
+	}
+}
+
+// TestWriteObjectKey_WithReadObjectKey tests that both directions work together:
+// write_object_key wraps POST/PUT bodies, read_object_key unwraps GET responses
+func TestWriteObjectKey_WithReadObjectKey(t *testing.T) {
+	var createBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case "POST":
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &createBody)
+			// API responds with wrapped response
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":   "combo-1",
+				"name": "combo-test",
+			})
+		case "GET":
+			// API returns wrapped GET response
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"result": map[string]interface{}{
+					"id":   "combo-1",
+					"name": "combo-test",
+				},
+				"success": true,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:                 server.URL,
+		Timeout:             2,
+		CreateReturnsObject: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/api/objects",
+		WriteObjectKey: "entry",
+		ReadObjectKey:  "result",
+		Data:           `{"id": "combo-1", "name": "combo-test"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	// Test CREATE: body should be wrapped
+	err = obj.CreateObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected create error: %v", err)
+	}
+
+	entry, ok := createBody["entry"]
+	if !ok {
+		t.Fatalf("POST body should have 'entry' wrapper, got: %v", createBody)
+	}
+	entryMap := entry.(map[string]interface{})
+	if entryMap["name"] != "combo-test" {
+		t.Errorf("POST body entry.name should be 'combo-test', got: %v", entryMap["name"])
+	}
+
+	// Test READ: response should be unwrapped
+	err = obj.ReadObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected read error: %v", err)
+	}
+
+	apiData := obj.GetApiData()
+	if apiData["id"] != "combo-1" {
+		t.Errorf("Expected id 'combo-1' after unwrapping, got: %v", apiData["id"])
+	}
+	if apiData["name"] != "combo-test" {
+		t.Errorf("Expected name 'combo-test' after unwrapping, got: %v", apiData["name"])
+	}
+	// Should NOT have 'success' or 'result' keys (they were stripped by read_object_key)
+	if _, exists := apiData["success"]; exists {
+		t.Error("Should not have 'success' key after read_object_key extraction")
+	}
+}
+
+// TestWriteObjectKey_CascadeFromProvider tests that write_object_key falls back to client-level config
+func TestWriteObjectKey_CascadeFromProvider(t *testing.T) {
+	var receivedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "cascade-1", "name": "test"})
+	}))
+	defer server.Close()
+
+	// Set write_object_key on the CLIENT (simulating provider-level config)
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:                server.URL,
+		Timeout:            2,
+		WriteReturnsObject: true,
+		WriteObjectKey:     "wrapper",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	// Object does NOT set write_object_key — should inherit from client
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path: "/api/objects",
+		Data: `{"id": "cascade-1", "name": "test"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	err = obj.CreateObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if _, ok := receivedBody["wrapper"]; !ok {
+		t.Fatalf("Expected client-level write_object_key 'wrapper' to be applied, got: %v", receivedBody)
+	}
+}
+
+// TestWriteObjectKey_ResourceOverridesProvider tests that resource-level write_object_key overrides provider
+func TestWriteObjectKey_ResourceOverridesProvider(t *testing.T) {
+	var receivedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "override-1", "name": "test"})
+	}))
+	defer server.Close()
+
+	// Provider sets "provider_wrapper"
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:                server.URL,
+		Timeout:            2,
+		WriteReturnsObject: true,
+		WriteObjectKey:     "provider_wrapper",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	// Resource overrides with "resource_wrapper"
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/api/objects",
+		WriteObjectKey: "resource_wrapper",
+		Data:           `{"id": "override-1", "name": "test"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	err = obj.CreateObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if _, ok := receivedBody["resource_wrapper"]; !ok {
+		t.Fatalf("Expected resource-level 'resource_wrapper' to override provider, got: %v", receivedBody)
+	}
+	if _, ok := receivedBody["provider_wrapper"]; ok {
+		t.Fatal("Provider-level 'provider_wrapper' should NOT be present when resource overrides")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -184,7 +184,7 @@ func (p *RestAPIProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			},
 			"read_object_key": schema.StringAttribute{
 				Optional:    true,
-				Description: "When set, this key will be used to extract an object from GET responses. For example, if the API wraps responses like {\"REALTIME\": {...actual object...}}, set this to 'REALTIME' to extract the inner object for state storage. Supports nested paths: 'data/items/0', 'result/resource'. This value may also be set via the REST_API_READ_OBJECT_KEY environment variable.",
+				Description: "When set, this key will be used to extract an object from GET responses. Useful for APIs that wrap responses in an envelope (e.g., {\"result\": {...}}, {\"data\": {...}}). Set to the wrapper key to extract the inner object before state comparison. Supports nested paths with '/' delimiter (e.g., 'data/items', 'response/result'). This value may also be set via the REST_API_READ_OBJECT_KEY environment variable.",
 			},
 			"rate_limit": schema.Float64Attribute{
 				Optional:    true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -44,6 +44,7 @@ type RestAPIProviderModel struct {
 	CreateReturnsObject types.Bool            `tfsdk:"create_returns_object"`
 	XSSIPrefix          types.String          `tfsdk:"xssi_prefix"`
 	ReadObjectKey       types.String          `tfsdk:"read_object_key"`
+	WriteObjectKey      types.String          `tfsdk:"write_object_key"`
 	RateLimit           types.Float64         `tfsdk:"rate_limit"`
 	TestPath            types.String          `tfsdk:"test_path"`
 	Debug               types.Bool            `tfsdk:"debug"`
@@ -185,6 +186,10 @@ func (p *RestAPIProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			"read_object_key": schema.StringAttribute{
 				Optional:    true,
 				Description: "When set, this key will be used to extract an object from GET responses. Useful for APIs that wrap responses in an envelope (e.g., {\"result\": {...}}, {\"data\": {...}}). Set to the wrapper key to extract the inner object before state comparison. Supports nested paths with '/' delimiter (e.g., 'data/items', 'response/result'). This value may also be set via the REST_API_READ_OBJECT_KEY environment variable.",
+			},
+			"write_object_key": schema.StringAttribute{
+				Optional:    true,
+				Description: "When set, POST and PUT request bodies will be wrapped under this key before sending to the API. Useful for APIs that require request data to be nested in an envelope (e.g., {\"entry\": {...}}, {\"request\": {...}}). Supports nested paths with '/' delimiter (e.g., 'request/data'). This value may also be set via the REST_API_WRITE_OBJECT_KEY environment variable.",
 			},
 			"rate_limit": schema.Float64Attribute{
 				Optional:    true,
@@ -335,6 +340,7 @@ func (p *RestAPIProvider) Configure(ctx context.Context, req provider.ConfigureR
 		CreateReturnsObject: existingOrEnvOrDefaultBool(&resp.Diagnostics, "create_returns_object", data.CreateReturnsObject, "REST_API_CRO", false, false),
 		XSSIPrefix:          existingOrEnvOrDefaultString(&resp.Diagnostics, "xssi_prefix", data.XSSIPrefix, "REST_API_XSSI_PREFIX", "", false),
 		ReadObjectKey:       existingOrEnvOrDefaultString(&resp.Diagnostics, "read_object_key", data.ReadObjectKey, "REST_API_READ_OBJECT_KEY", "", false),
+		WriteObjectKey:      existingOrEnvOrDefaultString(&resp.Diagnostics, "write_object_key", data.WriteObjectKey, "REST_API_WRITE_OBJECT_KEY", "", false),
 		RateLimit:           existingOrEnvOrDefaultFloat(&resp.Diagnostics, "rate_limit", data.RateLimit, "REST_API_RATE_LIMIT", math.MaxFloat64, false),
 		Debug:               existingOrEnvOrDefaultBool(&resp.Diagnostics, "debug", data.Debug, "REST_API_DEBUG", false, false),
 		CreateMethod:        existingOrEnvOrDefaultString(&resp.Diagnostics, "create_method", data.CreateMethod, "REST_API_CREATE_METHOD", "POST", false),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,6 +43,7 @@ type RestAPIProviderModel struct {
 	WriteReturnsObject  types.Bool            `tfsdk:"write_returns_object"`
 	CreateReturnsObject types.Bool            `tfsdk:"create_returns_object"`
 	XSSIPrefix          types.String          `tfsdk:"xssi_prefix"`
+	ReadObjectKey       types.String          `tfsdk:"read_object_key"`
 	RateLimit           types.Float64         `tfsdk:"rate_limit"`
 	TestPath            types.String          `tfsdk:"test_path"`
 	Debug               types.Bool            `tfsdk:"debug"`
@@ -180,6 +181,10 @@ func (p *RestAPIProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			"xssi_prefix": schema.StringAttribute{
 				Optional:    true,
 				Description: "Trim the xssi prefix from response string, if present, before parsing.",
+			},
+			"read_object_key": schema.StringAttribute{
+				Optional:    true,
+				Description: "When set, this key will be used to extract an object from GET responses. For example, if the API wraps responses like {\"REALTIME\": {...actual object...}}, set this to 'REALTIME' to extract the inner object for state storage. Supports nested paths: 'data/items/0', 'result/resource'. This value may also be set via the REST_API_READ_OBJECT_KEY environment variable.",
 			},
 			"rate_limit": schema.Float64Attribute{
 				Optional:    true,
@@ -329,6 +334,7 @@ func (p *RestAPIProvider) Configure(ctx context.Context, req provider.ConfigureR
 		WriteReturnsObject:  existingOrEnvOrDefaultBool(&resp.Diagnostics, "write_returns_object", data.WriteReturnsObject, "REST_API_WRO", false, false),
 		CreateReturnsObject: existingOrEnvOrDefaultBool(&resp.Diagnostics, "create_returns_object", data.CreateReturnsObject, "REST_API_CRO", false, false),
 		XSSIPrefix:          existingOrEnvOrDefaultString(&resp.Diagnostics, "xssi_prefix", data.XSSIPrefix, "REST_API_XSSI_PREFIX", "", false),
+		ReadObjectKey:       existingOrEnvOrDefaultString(&resp.Diagnostics, "read_object_key", data.ReadObjectKey, "REST_API_READ_OBJECT_KEY", "", false),
 		RateLimit:           existingOrEnvOrDefaultFloat(&resp.Diagnostics, "rate_limit", data.RateLimit, "REST_API_RATE_LIMIT", math.MaxFloat64, false),
 		Debug:               existingOrEnvOrDefaultBool(&resp.Diagnostics, "debug", data.Debug, "REST_API_DEBUG", false, false),
 		CreateMethod:        existingOrEnvOrDefaultString(&resp.Diagnostics, "create_method", data.CreateMethod, "REST_API_CREATE_METHOD", "POST", false),

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -214,7 +214,7 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 				},
 			},
 			"read_object_key": schema.StringAttribute{
-				Description: "Defaults to `read_object_key` set on the provider. Allows per-resource override. When set, this key is used to extract an object from GET responses. For example, if the API wraps responses like {\"REALTIME\": {...}}, set this to 'REALTIME'. Supports nested paths like 'data/items/0'.",
+				Description: "Defaults to `read_object_key` set on the provider. Allows per-resource override. When set, this key is used to extract an object from GET responses. Useful when the API wraps the response in an envelope. Supports nested paths with '/' delimiter (e.g., 'data/item', 'response/0').",
 				Optional:    true,
 				Computed:    true, // CRITICAL: Store in state to persist through Read cycles
 			},

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -52,6 +52,7 @@ type RestAPIObjectResourceModel struct {
 	IgnoreAllServerChanges types.Bool           `tfsdk:"ignore_all_server_changes"`
 	IgnoreServerAdditions  types.Bool           `tfsdk:"ignore_server_additions"`
 	ReadObjectKey          types.String         `tfsdk:"read_object_key"`
+	WriteObjectKey         types.String         `tfsdk:"write_object_key"`
 
 	ID             types.String `tfsdk:"id"`
 	APIData        types.Map    `tfsdk:"api_data"`
@@ -217,6 +218,11 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 				Description: "Defaults to `read_object_key` set on the provider. Allows per-resource override. When set, this key is used to extract an object from GET responses. Useful when the API wraps the response in an envelope. Supports nested paths with '/' delimiter (e.g., 'data/item', 'response/0').",
 				Optional:    true,
 				Computed:    true, // CRITICAL: Store in state to persist through Read cycles
+			},
+			"write_object_key": schema.StringAttribute{
+				Description: "Defaults to `write_object_key` set on the provider. Allows per-resource override. When set, POST and PUT request bodies are wrapped under this key before sending. Useful when the API requires data nested in an envelope (e.g., 'entry', 'request/data').",
+				Optional:    true,
+				Computed:    true, // Store in state to persist through Read cycles
 			},
 
 			"create_response": schema.StringAttribute{
@@ -704,8 +710,9 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		DestroyMethod: existingOrProviderOrDefaultString(model.DestroyMethod, client.Opts.DestroyMethod, "DELETE"),
 		DestroyData:   model.DestroyData.ValueString(),
 
-		QueryString:   existingOrDefaultString(model.QueryString, ""),
-		ReadObjectKey: existingOrProviderOrDefaultString(model.ReadObjectKey, client.Opts.ReadObjectKey, ""),
+		QueryString:    existingOrDefaultString(model.QueryString, ""),
+		ReadObjectKey:  existingOrProviderOrDefaultString(model.ReadObjectKey, client.Opts.ReadObjectKey, ""),
+		WriteObjectKey: existingOrProviderOrDefaultString(model.WriteObjectKey, client.Opts.WriteObjectKey, ""),
 	}
 
 	// Wire up read_search if configured
@@ -746,7 +753,8 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 func setResourceModelData(ctx context.Context, obj *apiclient.APIObject, data *RestAPIObjectResourceModel, diag *diag.Diagnostics) {
 	data.ID = types.StringValue(obj.ID)
 	data.APIResponse = types.StringValue(obj.GetApiResponse())
-	data.ReadObjectKey = types.StringValue(obj.GetReadObjectKey()) // Store resolved value in state
+	data.ReadObjectKey = types.StringValue(obj.GetReadObjectKey())   // Store resolved value in state
+	data.WriteObjectKey = types.StringValue(obj.GetWriteObjectKey()) // Store resolved value in state
 	v, d := types.MapValueFrom(ctx, types.StringType, obj.GetApiData())
 	data.APIData = v
 	diag.Append(d...)

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -51,6 +51,7 @@ type RestAPIObjectResourceModel struct {
 	IgnoreChangesTo        types.List           `tfsdk:"ignore_changes_to"`
 	IgnoreAllServerChanges types.Bool           `tfsdk:"ignore_all_server_changes"`
 	IgnoreServerAdditions  types.Bool           `tfsdk:"ignore_server_additions"`
+	ReadObjectKey          types.String         `tfsdk:"read_object_key"`
 
 	ID             types.String `tfsdk:"id"`
 	APIData        types.Map    `tfsdk:"api_data"`
@@ -211,6 +212,11 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 						CustomType:  jsontypes.NormalizedType{},
 					},
 				},
+			},
+			"read_object_key": schema.StringAttribute{
+				Description: "Defaults to `read_object_key` set on the provider. Allows per-resource override. When set, this key is used to extract an object from GET responses. For example, if the API wraps responses like {\"REALTIME\": {...}}, set this to 'REALTIME'. Supports nested paths like 'data/items/0'.",
+				Optional:    true,
+				Computed:    true, // CRITICAL: Store in state to persist through Read cycles
 			},
 
 			"create_response": schema.StringAttribute{
@@ -698,7 +704,8 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		DestroyMethod: existingOrProviderOrDefaultString(model.DestroyMethod, client.Opts.DestroyMethod, "DELETE"),
 		DestroyData:   model.DestroyData.ValueString(),
 
-		QueryString: existingOrDefaultString(model.QueryString, ""),
+		QueryString:   existingOrDefaultString(model.QueryString, ""),
+		ReadObjectKey: existingOrProviderOrDefaultString(model.ReadObjectKey, client.Opts.ReadObjectKey, ""),
 	}
 
 	// Wire up read_search if configured
@@ -739,6 +746,7 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 func setResourceModelData(ctx context.Context, obj *apiclient.APIObject, data *RestAPIObjectResourceModel, diag *diag.Diagnostics) {
 	data.ID = types.StringValue(obj.ID)
 	data.APIResponse = types.StringValue(obj.GetApiResponse())
+	data.ReadObjectKey = types.StringValue(obj.GetReadObjectKey()) // Store resolved value in state
 	v, d := types.MapValueFrom(ctx, types.StringType, obj.GetApiData())
 	data.APIData = v
 	diag.Append(d...)


### PR DESCRIPTION
## Summary

Adds the `read_object_key` parameter to extract data from wrapped GET responses before state comparison, eliminating false drift for APIs where GET response structure differs from POST/PUT request structure.

## Problem

Many REST APIs wrap successful responses in an envelope structure, but the provider compares this wrapped response directly to the unwrapped request data, causing false drift on every plan even when nothing changed:

**Example 1: Result Wrapper**
- POST/PUT sends: `{"name": "foo", "config": {...}}`
- GET returns: `{"result": {"name": "foo", "config": {...}}, "success": true}`
- Result: False drift detected (structural difference)

**Example 2: Nested Data Path**
- POST/PUT sends: `{"id": "123", "value": "bar"}`
- GET returns: `{"response": {"data": {"id": "123", "value": "bar"}}, "meta": {...}}`
- Result: False drift detected (wrapper structure differs)

This issue affects production deployments:
- Every `terraform plan` shows cosmetic drift
- Reviewer fatigue from noise
- Risk of approving real changes hidden in false positives
- Issue #314 open for 7+ months with community demand

## Solution

Implements `read_object_key` to extract the actual object from the wrapper **before** storing in Terraform state:

```hcl
provider "restapi" {
  uri = "https://api.example.com"
  read_object_key = "result"  # Provider-level default
}

resource "restapi_object" "example" {
  path = "/api/objects"
  read_object_key = "data"  # Resource-level override

  data = jsonencode({
    name = "my-resource"
    config = { setting = "value" }
  })
}
```

**How it works:**
1. POST/PUT sends: `{"name": "foo", "value": "bar"}`
2. GET returns: `{"result": {"name": "foo", "value": "bar"}}`
3. Provider extracts using `read_object_key = "result"`
4. Stores in state: `{"name": "foo", "value": "bar"}` (unwrapped)
5. Next plan compares unwrapped vs unwrapped → **no drift!**

**Supports nested paths:**
- Simple: `"result"`, `"data"`
- Nested: `"data/items"`, `"response/resource"`
- Array element: `"items/0"`

## Key Design Decisions

### 1. Naming: `read_object_key`
Follows existing provider patterns:
- `read_path`, `read_method`, `read_data` → `read_object_key` (consistent prefix)
- Aligns with `id_attribute` (extraction-focused configuration)
- Used in both provider and resource schemas

### 2. State Persistence
This implementation ensures configuration persists across operations:
- `read_object_key` marked as `Computed: true` in resource schema
- Resolved value stored in state via `GetReadObjectKey()` accessor
- Persists through Read/Import cycles

### 3. Extraction Point
Extraction happens in `ReadObject()` after `SendRequest()`, before `updateInternalState()`:
- Composes cleanly with `xssi_prefix` (both transformations applied in sequence)
- Localized to read operations (doesn't affect write paths)
- Follows same pattern as `read_search.results_key` extraction

### 4. Configuration Cascade
Matches `id_attribute` precedence pattern:
```
Resource-level read_object_key (highest priority)
  ↓ if null/empty
Provider-level read_object_key
  ↓ if null/empty
Environment variable: REST_API_READ_OBJECT_KEY
  ↓ if null/empty
Default: "" (no extraction - backward compatible)
```

## Backward Compatibility

**100% backward compatible** - No breaking changes:
- New optional parameter with empty string default
- Empty string = NO extraction (current behavior preserved)
- Existing resources without `read_object_key` work identically
- No schema version bump required
- All existing tests pass unchanged

## Changes Made

### Core Implementation
1. **[internal/apiclient/client.go](internal/apiclient/client.go)**: Add `ReadObjectKey` to client config
2. **[internal/apiclient/object.go](internal/apiclient/object.go)**: Extraction logic with cascade resolution
3. **[internal/provider/provider.go](internal/provider/provider.go)**: Provider-level schema and configuration
4. **[internal/provider/resource_api_object.go](internal/provider/resource_api_object.go)**: Resource-level schema with state persistence

### Tests
5. **[internal/apiclient/object_read_objectkey_test.go](internal/apiclient/object_read_objectkey_test.go)**: Comprehensive unit tests
   - Simple wrapper extraction
   - Nested path support (`data/items`)
   - Backward compatibility (empty key)
   - Error handling (key not found)
   - Composition with `xssi_prefix`
   - All tests passing

### Documentation
6. **[README.md](README.md)**: Added usage tip for wrapped API responses
7. **[examples/provider/provider.tf](examples/provider/provider.tf)**: Added commented example
8. **[examples/resources/restapi_object/resource_with_wrapped_response.tf](examples/resources/restapi_object/resource_with_wrapped_response.tf)**: Created comprehensive examples

## Testing

### Unit Tests
```bash
$ go test ./internal/apiclient -run TestReadObject_ReadObjectKey -v
=== RUN   TestReadObject_ReadObjectKey
=== RUN   TestReadObject_ReadObjectKey/simple_wrapper_extraction
=== RUN   TestReadObject_ReadObjectKey/nested_path_extraction
=== RUN   TestReadObject_ReadObjectKey/no_extraction_empty_key
=== RUN   TestReadObject_ReadObjectKey/error_key_not_found
=== RUN   TestReadObject_ReadObjectKey/deep_nested_path
--- PASS: TestReadObject_ReadObjectKey (0.00s)
    --- PASS: TestReadObject_ReadObjectKey/simple_wrapper_extraction (0.00s)
    --- PASS: TestReadObject_ReadObjectKey/nested_path_extraction (0.00s)
    --- PASS: TestReadObject_ReadObjectKey/no_extraction_empty_key (0.00s)
    --- PASS: TestReadObject_ReadObjectKey/error_key_not_found (0.00s)
    --- PASS: TestReadObject_ReadObjectKey/deep_nested_path (0.00s)
PASS

$ go test ./internal/apiclient -run TestReadObject_ReadObjectKeyWithXSSIPrefix -v
=== RUN   TestReadObject_ReadObjectKeyWithXSSIPrefix
--- PASS: TestReadObject_ReadObjectKeyWithXSSIPrefix (0.00s)
PASS
```

### Backward Compatibility
```bash
$ go build -v ./...
# Build successful - no breaking changes

$ make test
# All existing tests pass
```

### Integration Tests

Complete CRUD lifecycle validated with mock API server returning wrapped responses:

**CREATE**: Resources created successfully with wrapped responses
```bash
terraform apply
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

**READ**: No false drift detected
```bash
terraform plan
No changes. Your infrastructure matches the configuration.
```

**UPDATE**: Real changes detected correctly, no-op apply works
```bash
terraform apply  # After config change
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

terraform apply  # No config change
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

**DELETE**: Clean resource removal

### Corner Cases Tested

**Nested Paths** (`data/item`): Correctly extracts from multi-level structures

**Array Elements** (`items/0`): Successfully extracts first element from array responses

**Deep Nesting** (`response/data/items/content`): Handles 4+ level deep paths

**Invalid Keys**: Fails gracefully with clear error messages
```
Error: Could not create API object: failed to extract read_object_key
'nonexistent_key': Resulting map does not have key 'nonexistent_key'.
Available: result,status
```

**Out of Bounds** (`items/25` when array has 2 elements): Clear error with available indices
```
Error: failed to extract read_object_key 'items/25':
Resulting map at '/items' does not have key '25'. Available: 0,1
```

**Empty Key** (`""`): No extraction performed (backward compatible behavior)

## Environment Variable Support

Satisfies Contributing Rule #4:
```bash
export REST_API_READ_OBJECT_KEY="result"
terraform plan  # Uses "result" if not overridden in config
```

## Real-World Use Cases

This feature solves documented issues for:
- Generic REST APIs with envelope patterns (`{"result": {...}}`, `{"data": {...}}`)
- APIs where GET wrapping differs from POST/PUT structure
- Dynamic wrapper keys that vary by resource type
- Any API using response envelopes with success metadata

## Fixes

- Closes #314 (7+ month old issue with community demand)
- Builds on work started in PR #342 by @exocom

## Contribution Checklist

Per [README Contributing section](README.md):
- [x] `go fmt` run on all files
- [x] Test cases added ([object_read_objectkey_test.go](internal/apiclient/object_read_objectkey_test.go))
- [x] All tests pass (unit tests verified, no `scripts/test.sh` in repo)
- [x] Environment variable support: `REST_API_READ_OBJECT_KEY`
- [x] Breaking changes: **None** (new optional parameter)

## Commits

```
f874b4b docs: Add read_object_key usage examples and documentation
894573e test: Add unit tests for read_object_key extraction
2eb69a5 docs: Use generic examples in read_object_key descriptions
6e3cba8 feat: Add read_object_key resource-level configuration with state persistence
b64cb3a feat: Add read_object_key provider-level configuration
8148dd4 feat: Add read_object_key to APIClient and APIObject
```

---

**Community Impact**: This PR addresses a common pain point (issue #314) with production validation. The implementation is conservative, fully backward compatible, and follows established provider patterns. Happy to address any feedback!

cc: @DRuggeri 