### PR TITLE
fix: prevent inconsistent result error on update with ignore_server_additions

### DIFF
--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -455,11 +455,26 @@ func (r *RestAPIObjectResource) ModifyPlan(ctx context.Context, req resource.Mod
 	plan.CreateResponse = state.CreateResponse
 
 	if !plan.IgnoreServerAdditions.IsNull() && plan.IgnoreServerAdditions.ValueBool() {
-		// ignore_server_additions: Read preserves user config in state.Data,
-		// so we just preserve api_data/api_response if user didn't change anything
-		if plan.Data.Equal(state.Data) {
+		// ignore_server_additions: Read preserves user config in state.Data.
+		// Only lock api_data/api_response to the prior state when we are certain no
+		// update will run. An update is triggered by changes to data OR update_data
+		// (or other update-path attributes), so check both. If either is changing,
+		// mark api_data/api_response as unknown so Terraform does not enforce a
+		// specific post-apply value — the server may change fields like updated_at
+		// which would otherwise cause "inconsistent result after apply" errors.
+		willUpdate := !plan.Data.Equal(state.Data) ||
+			!plan.UpdateData.Equal(state.UpdateData) ||
+			!plan.UpdatePath.Equal(state.UpdatePath) ||
+			!plan.UpdateMethod.Equal(state.UpdateMethod) ||
+			!plan.Path.Equal(state.Path) ||
+			!plan.ObjectID.Equal(state.ObjectID)
+
+		if !willUpdate {
 			plan.APIData = state.APIData
 			plan.APIResponse = state.APIResponse
+		} else {
+			plan.APIData = types.MapUnknown(types.StringType)
+			plan.APIResponse = types.StringUnknown()
 		}
 	} else {
 		// Normal flow: normalize null fields that server omits

--- a/internal/provider/resource_api_object_features_test.go
+++ b/internal/provider/resource_api_object_features_test.go
@@ -447,6 +447,96 @@ resource "restapi_object" "Test" {
 	})
 }
 
+// TestAccRestApiObject_IgnoreServerAdditions_Update tests that updating a resource with
+// ignore_server_additions = true does not produce an "inconsistent result after apply" error
+// when update_data changes but data stays the same.
+//
+// This is the real-world failure mode: data is unchanged (so ModifyPlan locks plan.APIData to
+// the prior state value), but the update still runs (because update_data changed), and the
+// server returns different api_data — causing "Provider produced inconsistent result after apply".
+func TestAccRestApiObject_IgnoreServerAdditions_Update(t *testing.T) {
+	debug := false
+
+	apiServerObjects := make(map[string]map[string]interface{})
+
+	svr := fakeserver.NewFakeServer(8130, apiServerObjects, map[string]string{}, true, debug, "")
+	defer svr.Shutdown()
+
+	resource.UnitTest(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 func() { svr.StartInBackground() },
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create
+				Config: `
+provider "restapi" {
+  uri                   = "http://127.0.0.1:8130"
+  write_returns_object  = true
+  create_returns_object = true
+}
+
+resource "restapi_object" "Test" {
+  path                    = "/api/objects"
+  data                    = "{ \"id\": \"isa1\", \"name\": \"Original\" }"
+  update_data             = "{ \"id\": \"isa1\", \"name\": \"Original\" }"
+  ignore_server_additions = true
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("restapi_object.Test", "id", "isa1"),
+					resource.TestCheckResourceAttr("restapi_object.Test", "api_data.name", "Original"),
+				),
+			},
+			{
+				// Step 2: No-op — nothing changes, plan must be empty.
+				// Regression guard: api_data must be preserved (not shown as unknown)
+				// when no update is triggered.
+				Config: `
+provider "restapi" {
+  uri                   = "http://127.0.0.1:8130"
+  write_returns_object  = true
+  create_returns_object = true
+}
+
+resource "restapi_object" "Test" {
+  path                    = "/api/objects"
+  data                    = "{ \"id\": \"isa1\", \"name\": \"Original\" }"
+  update_data             = "{ \"id\": \"isa1\", \"name\": \"Original\" }"
+  ignore_server_additions = true
+}
+`,
+				PlanOnly: true,
+			},
+			{
+				// Step 3: update_data changes but data stays the same.
+				// Without the fix: ModifyPlan locks plan.APIData to the prior state value,
+				// the update runs (triggered by update_data change), server returns new
+				// api_data, and Terraform throws "Provider produced inconsistent result after apply".
+				Config: `
+provider "restapi" {
+  uri                   = "http://127.0.0.1:8130"
+  write_returns_object  = true
+  create_returns_object = true
+}
+
+resource "restapi_object" "Test" {
+  path                    = "/api/objects"
+  data                    = "{ \"id\": \"isa1\", \"name\": \"Original\" }"
+  update_data             = "{ \"id\": \"isa1\", \"name\": \"Original\", \"extra\": \"added\" }"
+  ignore_server_additions = true
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("restapi_object.Test", "id", "isa1"),
+					resource.TestCheckResourceAttr("restapi_object.Test", "api_data.extra", "added"),
+					resource.TestCheckResourceAttrSet("restapi_object.Test", "api_response"),
+				),
+			},
+		},
+	})
+}
+
 // TestAccRestApiObject_ReadPatchRemove tests using search_patch to remove unwanted fields
 func TestAccRestApiObject_ReadPatchRemove(t *testing.T) {
 	debug := false


### PR DESCRIPTION
Fixes #355

## Problem

When `ignore_server_additions = true` and an update is triggered by a change to `update_data`, `update_path`, `update_method`, `path`, or `object_id` (while `data` itself is unchanged), `ModifyPlan` was locking `plan.APIData` to the prior state value. After the update the server returns new `api_data` (e.g. a changed `updated_at` timestamp), which no longer matches the locked planned value, producing:

```
Error: Provider produced inconsistent result after apply
.api_data["metadata"]: updated_at value changed
```

## Root cause

`ModifyPlan` checked only `plan.Data.Equal(state.Data)` to decide whether to lock `api_data`. This missed the case where `data` is unchanged but another attribute (e.g. `update_data`) triggers an update.

## Fix

Mark `api_data` and `api_response` as unknown in the plan whenever any update-triggering attribute has changed, so Terraform does not enforce a specific post-apply value.

## Test

Added `TestAccRestApiObject_IgnoreServerAdditions_Update` which:
- Reproduces the exact failure (confirmed failing before the fix)
- Includes a no-op step as a regression guard to verify `api_data` is still preserved when nothing changes