### PR TITLE
fix: remove state when object not found in Read and ImportState

### DIFF
--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -342,6 +342,11 @@ func (r *RestAPIObjectResource) Read(ctx context.Context, req resource.ReadReque
 		)
 		return
 	}
+	if obj.ID == "" {
+		tflog.Info(ctx, "Read: object not found, removing from state")
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	objString := obj.GetApiResponse()
 	tflog.Debug(ctx, "Read resource", map[string]interface{}{"id": obj.ID})
 
@@ -661,6 +666,14 @@ func (r *RestAPIObjectResource) ImportState(ctx context.Context, req resource.Im
 		resp.Diagnostics.AddError(
 			"Error Reading API Object",
 			fmt.Sprintf("Could not read API object: %s", err.Error()),
+		)
+		return
+	}
+
+	if obj.ID == "" {
+		resp.Diagnostics.AddError(
+			"Error Reading API Object",
+			fmt.Sprintf("Could not import api_object '%s': object not found", req.ID),
 		)
 		return
 	}


### PR DESCRIPTION
## Problem

`ReadObject()` signals that an object no longer exists by setting `obj.ID = ""` and returning `nil` (no error). This happens in two cases:
- `read_search` is configured and no result matches the search key/value
- the API returns HTTP 404

Both `Read()` and `ImportState()` call `ReadObject()` but never inspect `obj.ID` afterward. This violates the Plugin Framework contract, which requires calling `resp.State.RemoveResource(ctx)` when a resource no longer exists. Ref https://developer.hashicorp.com/terraform/plugin/framework/resources/read
> Similar to #269 / #282 which fixed this for the v2.x SDK. The v3.0.0
> Plugin Framework rewrite reintroduced the same gap in
> `internal/provider/resource_api_object.go`.

---
## Symptoms
### `Read()`: broken drift detection
1. Apply a `restapi_object` resource.
2. Delete the underlying API object out-of-band.
3. Run `terraform plan`.

**Expected:** Terraform detects the resource is gone and plans to recreate it.
**Actual:** the resource is written back to state with an empty `id` field.

The next `terraform plan` or `terraform apply` fails with:
```
Error: cannot read an object unless the ID has been set
```
The user must manually run `terraform state rm` to unblock.

### `ImportState()`: silent broken state on missing object
`terraform import restapi_object.foo /api/objects/missing-id` when the object does not exist:
- `ReadObject()` clears `obj.ID` and returns nil, but `ImportState()` proceeds to write state with an empty ID instead of returning an error.

---
## Fix
After each `ReadObject()` call, check `obj.ID == ""` and take the correct action.
**`Read()`**: call `RemoveResource` so Terraform treats the resource as deleted and plans to recreate it:
```go
if obj.ID == "" {
    tflog.Info(ctx, "Read: object not found, removing from state")
    resp.State.RemoveResource(ctx)
    return
}
```

**`ImportState()`**: return a diagnostic error:
```go
if obj.ID == "" {
    resp.Diagnostics.AddError(
        "Error Reading API Object",
        fmt.Sprintf("Could not import api_object '%s': object not found", req.ID),
    )
    return
}
```
The `Update()` error-recovery path also calls `ReadObject()` as a best-effort fallback after a failed update and is intentionally left unchanged.