### PR TITLE
fix: prevent inconsistent result error on update with ignore_all_server_changes

### DIFF
--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -555,7 +555,13 @@ func (r *RestAPIObjectResource) Update(ctx context.Context, req resource.UpdateR
 		}
 	}
 
-	setResourceModelData(ctx, obj, &plan, &resp.Diagnostics)
+	if !plan.IgnoreAllServerChanges.IsNull() && plan.IgnoreAllServerChanges.ValueBool() {
+		plan.ID = state.ID
+		plan.APIData = state.APIData
+		plan.APIResponse = state.APIResponse
+	} else {
+		setResourceModelData(ctx, obj, &plan, &resp.Diagnostics)
+	}
 	plan.CreateResponse = state.CreateResponse
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/provider/resource_api_object_features_test.go
+++ b/internal/provider/resource_api_object_features_test.go
@@ -91,6 +91,75 @@ resource "restapi_object" "Test" {
 	})
 }
 
+// TestAccRestApiObject_IgnoreAllServerChanges_Update verifies that updating a resource
+// with ignore_all_server_changes = true does not cause "Provider produced inconsistent
+// result after apply" errors. The Update function must preserve api_data and api_response
+// from the prior state instead of overwriting them from the server response.
+func TestAccRestApiObject_IgnoreAllServerChanges_Update(t *testing.T) {
+	debug := false
+
+	apiServerObjects := make(map[string]map[string]interface{})
+
+	svr := fakeserver.NewFakeServer(8130, apiServerObjects, map[string]string{}, true, debug, "")
+	defer svr.Shutdown()
+
+	resource.UnitTest(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 func() { svr.StartInBackground() },
+		Steps: []resource.TestStep{
+			{
+				Config: `
+provider "restapi" {
+  uri                   = "http://127.0.0.1:8130"
+  write_returns_object  = false
+  create_returns_object = true
+}
+
+resource "restapi_object" "Test" {
+  path                      = "/api/objects"
+  update_method             = "PUT"
+  ignore_all_server_changes = true
+  data                      = jsonencode({ id = "iac1", name = "Original", secret = "s3cret" })
+  update_data               = jsonencode({ name = "Original" })
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("restapi_object.Test", "id", "iac1"),
+					resource.TestCheckResourceAttr("restapi_object.Test", "api_data.name", "Original"),
+				),
+			},
+			{
+				// Change update_data to trigger an in-place update.
+				// Before the fix, this would fail with:
+				//   "Provider produced inconsistent result after apply"
+				//   .api_data["name"]: was "Original", but now "Changed"
+				Config: `
+provider "restapi" {
+  uri                   = "http://127.0.0.1:8130"
+  write_returns_object  = false
+  create_returns_object = true
+}
+
+resource "restapi_object" "Test" {
+  path                      = "/api/objects"
+  update_method             = "PUT"
+  ignore_all_server_changes = true
+  data                      = jsonencode({ id = "iac1", name = "Original", secret = "s3cret" })
+  update_data               = jsonencode({ name = "Changed" })
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("restapi_object.Test", "id", "iac1"),
+					// api_data should still show the original value because
+					// ignore_all_server_changes preserves state from before the update
+					resource.TestCheckResourceAttr("restapi_object.Test", "api_data.name", "Original"),
+				),
+			},
+		},
+	})
+}
+
 // TestAccRestApiObject_ForceNew tests that the force_new attribute works correctly:
 // - Changing fields NOT in force_new should update in-place (PUT)
 // - Changing fields in force_new should trigger destroy+recreate (DELETE+POST)


### PR DESCRIPTION
## Summary

`Update` does not respect `ignore_all_server_changes`, causing "Provider produced inconsistent result after apply" when `update_data` changes a field that the server echoes back.

This is the same class of bug as #356 (which fixes `ignore_server_additions`), but for the `ignore_all_server_changes` code path.

## Problem

`ModifyPlan` correctly preserves `api_data` and `api_response` from prior state when `ignore_all_server_changes = true` — telling Terraform these computed attributes won't change during apply.

However, `Update` unconditionally calls `setResourceModelData`, which overwrites `api_data` and `api_response` with values from the server response (either from the write response or the subsequent GET). When the update changes a field (e.g. `name`), the server returns the new value, creating a mismatch between what the plan promised and what the apply produced:

```
Error: Provider produced inconsistent result after apply

.api_data["name"]: was cty.StringVal("old"), but now cty.StringVal("new").
```

This makes `ignore_all_server_changes` incompatible with `update_data` for any field the server echoes back.

## Reproduction

```hcl
resource "restapi_object" "example" {
  path                      = "/api/resources"
  update_method             = "PATCH"
  ignore_all_server_changes = true

  data = jsonencode({
    name       = var.name
    secret_key = var.secret  # sensitive, only needed on creation
  })

  update_data = jsonencode({
    name = var.name
  })

  lifecycle {
    ignore_changes = [data]
  }
}
```

1. `terraform apply` — creates the resource successfully.
2. Change `var.name` and run `terraform apply` — plan correctly shows only `update_data` changing.
3. Apply fails with "Provider produced inconsistent result".

## Fix

In `Update`, when `ignore_all_server_changes` is true, preserve `api_data` and `api_response` from prior state instead of overwriting them from the server response. This mirrors the existing pattern in `ModifyPlan`.

## Test plan

- [x] Added `TestAccRestApiObject_IgnoreAllServerChanges_Update` — creates a resource with `ignore_all_server_changes = true` and `update_data`, then changes `update_data` in a second step. Without the fix, step 2 fails with "Provider produced inconsistent result".
- [x] Existing `TestAccRestApiObject_IgnoreAllServerChanges` still passes.
- [x] Full test suite passes.
