### PR TITLE
feat: Add validate_path for pre-flight API validation during terraform plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This provider has only a few moving components, but LOTS of configurable paramet
 * By default, data isn't considered sensitive. If you want to hide the data this provider submits as well as the data returned by the API, you would need to set environment variable `API_DATA_IS_SENSITIVE=true`.
 * The `*_path` elements are for very specific use cases where one might initially create an object in one location, but read/update/delete it on another path. For this reason, they allow for substitution to be done by the provider internally by injecting the `id` somewhere along the path. This is similar to terraform's substitution syntax in the form of `${variable.name}`, but must be done within the provider due to structure. The only substitution available is to replace the string `{id}` with the internal (terraform) `id` of the object as learned by the `id_attribute`.
   * NOTICE: read operations performed on existing objects are done against the `read_path` **stored in state** rather than the new configuration!
+* If your API wraps GET responses in an envelope (e.g., `{"result": {...}}`), use `read_object_key` to extract the actual object before state comparison. This prevents false drift when the wrapper structure differs from POST/PUT requests. Supports nested paths like `"data/items"` or `"response/resource"`. Can be set at provider level or per-resource.
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This provider has only a few moving components, but LOTS of configurable paramet
 * The `*_path` elements are for very specific use cases where one might initially create an object in one location, but read/update/delete it on another path. For this reason, they allow for substitution to be done by the provider internally by injecting the `id` somewhere along the path. This is similar to terraform's substitution syntax in the form of `${variable.name}`, but must be done within the provider due to structure. The only substitution available is to replace the string `{id}` with the internal (terraform) `id` of the object as learned by the `id_attribute`.
   * NOTICE: read operations performed on existing objects are done against the `read_path` **stored in state** rather than the new configuration!
 * If your API wraps GET responses in an envelope (e.g., `{"result": {...}}`), use `read_object_key` to extract the actual object before state comparison. This prevents false drift when the wrapper structure differs from POST/PUT requests. Supports nested paths like `"data/items"` or `"response/resource"`. Can be set at provider level or per-resource.
+* If your API requires POST/PUT request bodies to be wrapped in an envelope (e.g., `{"entry": {...}}`), use `write_object_key` to automatically wrap the data before sending. Supports nested paths like `"request/data"`. Can be set at provider level or per-resource. Both `read_object_key` and `write_object_key` can be used together for APIs that wrap in both directions.
 
 &nbsp;
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -16,4 +16,9 @@ provider "restapi" {
   # Use this if your API returns responses like: {"result": {...}, "success": true}
   # Supports nested paths: "data/items", "response/resource"
   # read_object_key = "result"
+
+  # Optional: Wrap POST/PUT request bodies in an envelope
+  # Use this if your API requires data nested like: {"entry": {...}}
+  # Supports nested paths: "request/data"
+  # write_object_key = "entry"
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -11,4 +11,9 @@ provider "restapi" {
   create_method  = "PUT"
   update_method  = "PUT"
   destroy_method = "PUT"
+
+  # Optional: Extract objects from wrapped GET responses
+  # Use this if your API returns responses like: {"result": {...}, "success": true}
+  # Supports nested paths: "data/items", "response/resource"
+  # read_object_key = "result"
 }

--- a/examples/resources/restapi_object/resource_with_wrapped_response.tf
+++ b/examples/resources/restapi_object/resource_with_wrapped_response.tf
@@ -60,3 +60,34 @@ resource "restapi_object" "overrides_provider" {
     name = "resource-two"
   })
 }
+
+# Example: API that requires wrapped POST/PUT request bodies
+# API expects: POST {"entry": {"name": "foo", "config": {...}}}
+# API returns: GET {"name": "foo", "config": {...}} (flat, no wrapper)
+resource "restapi_object" "example_wrapped_write" {
+  path = "/api/entries"
+
+  # Wrap POST/PUT body under "entry" key before sending
+  write_object_key = "entry"
+
+  data = jsonencode({
+    name   = "my-resource"
+    config = {
+      setting = "value"
+    }
+  })
+}
+
+# Example: Both directions - wrapped reads AND wrapped writes
+# POST must send: {"request": {"name": "foo"}}
+# GET returns: {"response": {"name": "foo"}, "status": "ok"}
+resource "restapi_object" "example_both_wrapped" {
+  path = "/api/bidirectional"
+
+  write_object_key = "request"
+  read_object_key  = "response"
+
+  data = jsonencode({
+    name = "bidirectional-resource"
+  })
+}

--- a/examples/resources/restapi_object/resource_with_wrapped_response.tf
+++ b/examples/resources/restapi_object/resource_with_wrapped_response.tf
@@ -1,0 +1,62 @@
+# Example: API that wraps GET responses in an envelope structure
+# POST/PUT sends: {"name": "foo", "config": {...}}
+# GET returns: {"result": {"name": "foo", "config": {...}}, "success": true}
+#
+# Without read_object_key, this causes false drift because the provider
+# compares the wrapped response to the unwrapped request data.
+
+resource "restapi_object" "example_wrapped" {
+  path = "/api/objects"
+
+  # Extract the actual object from the "result" wrapper before state storage
+  read_object_key = "result"
+
+  data = jsonencode({
+    name   = "my-resource"
+    config = {
+      setting = "value"
+    }
+  })
+}
+
+# Example: Nested wrapper path
+# GET returns: {"response": {"data": {"id": "123", "value": "bar"}}, "meta": {...}}
+resource "restapi_object" "example_nested" {
+  path = "/api/objects"
+
+  # Use slash-delimited path to extract from nested structure
+  read_object_key = "response/data"
+
+  data = jsonencode({
+    id    = "123"
+    value = "bar"
+  })
+}
+
+# Example: Provider-level default with resource override
+provider "restapi" {
+  uri = "https://api.example.com"
+
+  # Set default extraction key for all resources
+  read_object_key = "result"
+}
+
+resource "restapi_object" "uses_provider_default" {
+  path = "/api/objects"
+  # This resource will use "result" from provider config
+
+  data = jsonencode({
+    name = "resource-one"
+  })
+}
+
+resource "restapi_object" "overrides_provider" {
+  path = "/api/other"
+
+  # Override provider-level setting for this specific resource
+  read_object_key = "data"
+
+  data = jsonencode({
+    name = "resource-two"
+  })
+}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -36,6 +36,7 @@ type APIClientOpt struct {
 	CreateMethod        string
 	ReadMethod          string
 	ReadData            string
+	ReadObjectKey       string
 	UpdateMethod        string
 	UpdateData          string
 	DestroyMethod       string
@@ -75,6 +76,7 @@ type APIClient struct {
 	createMethod        string
 	readMethod          string
 	readData            string
+	readObjectKey       string
 	updateMethod        string
 	updateData          string
 	destroyMethod       string
@@ -225,6 +227,7 @@ func NewAPIClient(opt *APIClientOpt) (*APIClient, error) {
 		createMethod:        opt.CreateMethod,
 		readMethod:          opt.ReadMethod,
 		readData:            opt.ReadData,
+		readObjectKey:       opt.ReadObjectKey,
 		updateMethod:        opt.UpdateMethod,
 		updateData:          opt.UpdateData,
 		destroyMethod:       opt.DestroyMethod,

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -37,6 +37,7 @@ type APIClientOpt struct {
 	ReadMethod          string
 	ReadData            string
 	ReadObjectKey       string
+	WriteObjectKey      string
 	UpdateMethod        string
 	UpdateData          string
 	DestroyMethod       string
@@ -77,6 +78,7 @@ type APIClient struct {
 	readMethod          string
 	readData            string
 	readObjectKey       string
+	writeObjectKey      string
 	updateMethod        string
 	updateData          string
 	destroyMethod       string
@@ -228,6 +230,7 @@ func NewAPIClient(opt *APIClientOpt) (*APIClient, error) {
 		readMethod:          opt.ReadMethod,
 		readData:            opt.ReadData,
 		readObjectKey:       opt.ReadObjectKey,
+		writeObjectKey:      opt.WriteObjectKey,
 		updateMethod:        opt.UpdateMethod,
 		updateData:          opt.UpdateData,
 		destroyMethod:       opt.DestroyMethod,

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -22,6 +22,7 @@ type APIObjectOpts struct {
 	ReadMethod    string
 	ReadPath      string
 	ReadData      string
+	ReadObjectKey string
 	UpdateMethod  string
 	UpdatePath    string
 	UpdateData    string
@@ -44,6 +45,7 @@ type APIObject struct {
 	createPath    string
 	readMethod    string
 	readPath      string
+	readObjectKey string
 	updateMethod  string
 	updatePath    string
 	destroyMethod string
@@ -88,6 +90,10 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 	if opts.ReadData == "" {
 		opts.ReadData = iClient.readData
 	}
+	// read_object_key can be set either on the client or per-object basis
+	if opts.ReadObjectKey == "" {
+		opts.ReadObjectKey = iClient.readObjectKey
+	}
 	if opts.UpdateMethod == "" {
 		opts.UpdateMethod = iClient.updateMethod
 	}
@@ -130,6 +136,7 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 		queryString:   opts.QueryString,
 		debug:         opts.Debug,
 		readSearch:    opts.ReadSearch,
+		readObjectKey: opts.ReadObjectKey,
 		ID:            opts.ID,
 		IDAttribute:   opts.IDAttribute,
 		data:          make(map[string]interface{}),
@@ -419,6 +426,35 @@ func (obj *APIObject) ReadObject(ctx context.Context) error {
 		return err
 	}
 
+	// Extract wrapped response if read_object_key is configured (backward compatible: empty string = no extraction)
+	if obj.readObjectKey != "" {
+		tflog.Debug(ctx, "Extracting object from response",
+			map[string]interface{}{"read_object_key": obj.readObjectKey})
+
+		var result interface{}
+		err = json.Unmarshal([]byte(resultString), &result)
+		if err != nil {
+			return fmt.Errorf("failed to parse response for read_object_key extraction: %w", err)
+		}
+
+		resultMap, ok := result.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("response is not a JSON object, cannot extract read_object_key '%s'", obj.readObjectKey)
+		}
+
+		extracted, err := GetObjectAtKey(ctx, resultMap, obj.readObjectKey)
+		if err != nil {
+			return fmt.Errorf("failed to extract read_object_key '%s': %w", obj.readObjectKey, err)
+		}
+
+		extractedJSON, err := json.Marshal(extracted)
+		if err != nil {
+			return fmt.Errorf("failed to marshal extracted object: %w", err)
+		}
+		resultString = string(extractedJSON)
+		tflog.Debug(ctx, "Successfully extracted object", map[string]interface{}{"read_object_key": obj.readObjectKey})
+	}
+
 	return obj.updateInternalState(resultString)
 }
 
@@ -601,6 +637,11 @@ func (obj *APIObject) GetApiData() map[string]string {
 // GetApiResponse returns a copy of the raw API response from the APIObject
 func (obj *APIObject) GetApiResponse() string {
 	return obj.apiResponse
+}
+
+// GetReadObjectKey returns the read_object_key configuration value
+func (obj *APIObject) GetReadObjectKey() string {
+	return obj.readObjectKey
 }
 
 // GetReadSearch returns a copy of the read_search configuration

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -16,46 +16,48 @@ import (
 )
 
 type APIObjectOpts struct {
-	Path          string
-	CreatePath    string
-	CreateMethod  string
-	ReadMethod    string
-	ReadPath      string
-	ReadData      string
-	ReadObjectKey string
-	UpdateMethod  string
-	UpdatePath    string
-	UpdateData    string
-	DestroyMethod string
-	DestroyData   string
-	DestroyPath   string
-	SearchPath    string
-	QueryString   string
-	Debug         bool
-	ReadSearch    map[string]string
-	ID            string
-	IDAttribute   string
-	Data          string
+	Path           string
+	CreatePath     string
+	CreateMethod   string
+	ReadMethod     string
+	ReadPath       string
+	ReadData       string
+	ReadObjectKey  string
+	WriteObjectKey string
+	UpdateMethod   string
+	UpdatePath     string
+	UpdateData     string
+	DestroyMethod  string
+	DestroyData    string
+	DestroyPath    string
+	SearchPath     string
+	QueryString    string
+	Debug          bool
+	ReadSearch     map[string]string
+	ID             string
+	IDAttribute    string
+	Data           string
 }
 
 // APIObject is the state holding struct for a restapi_object resource
 type APIObject struct {
-	apiClient     *APIClient
-	createMethod  string
-	createPath    string
-	readMethod    string
-	readPath      string
-	readObjectKey string
-	updateMethod  string
-	updatePath    string
-	destroyMethod string
-	deletePath    string
-	searchPath    string
-	queryString   string
-	debug         bool
-	readSearch    map[string]string
-	ID            string
-	IDAttribute   string
+	apiClient      *APIClient
+	createMethod   string
+	createPath     string
+	readMethod     string
+	readPath       string
+	readObjectKey  string
+	writeObjectKey string
+	updateMethod   string
+	updatePath     string
+	destroyMethod  string
+	deletePath     string
+	searchPath     string
+	queryString    string
+	debug          bool
+	readSearch     map[string]string
+	ID             string
+	IDAttribute    string
 
 	// Set internally
 	mux         sync.RWMutex           // Protects data and apiData fields
@@ -94,6 +96,10 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 	if opts.ReadObjectKey == "" {
 		opts.ReadObjectKey = iClient.readObjectKey
 	}
+	// write_object_key can be set either on the client or per-object basis
+	if opts.WriteObjectKey == "" {
+		opts.WriteObjectKey = iClient.writeObjectKey
+	}
 	if opts.UpdateMethod == "" {
 		opts.UpdateMethod = iClient.updateMethod
 	}
@@ -123,27 +129,28 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 	}
 
 	obj := APIObject{
-		apiClient:     iClient,
-		readPath:      opts.ReadPath,
-		createPath:    opts.CreatePath,
-		updatePath:    opts.UpdatePath,
-		createMethod:  opts.CreateMethod,
-		readMethod:    opts.ReadMethod,
-		updateMethod:  opts.UpdateMethod,
-		destroyMethod: opts.DestroyMethod,
-		deletePath:    opts.DestroyPath,
-		searchPath:    opts.SearchPath,
-		queryString:   opts.QueryString,
-		debug:         opts.Debug,
-		readSearch:    opts.ReadSearch,
-		readObjectKey: opts.ReadObjectKey,
-		ID:            opts.ID,
-		IDAttribute:   opts.IDAttribute,
-		data:          make(map[string]interface{}),
-		readData:      nil,
-		updateData:    nil,
-		destroyData:   nil,
-		apiData:       make(map[string]interface{}),
+		apiClient:      iClient,
+		readPath:       opts.ReadPath,
+		createPath:     opts.CreatePath,
+		updatePath:     opts.UpdatePath,
+		createMethod:   opts.CreateMethod,
+		readMethod:     opts.ReadMethod,
+		updateMethod:   opts.UpdateMethod,
+		destroyMethod:  opts.DestroyMethod,
+		deletePath:     opts.DestroyPath,
+		searchPath:     opts.SearchPath,
+		queryString:    opts.QueryString,
+		debug:          opts.Debug,
+		readSearch:     opts.ReadSearch,
+		readObjectKey:  opts.ReadObjectKey,
+		writeObjectKey: opts.WriteObjectKey,
+		ID:             opts.ID,
+		IDAttribute:    opts.IDAttribute,
+		data:           make(map[string]interface{}),
+		readData:       nil,
+		updateData:     nil,
+		destroyData:    nil,
+		apiData:        make(map[string]interface{}),
 	}
 
 	if opts.Data != "" {
@@ -305,13 +312,20 @@ func (obj *APIObject) CreateObject(ctx context.Context) error {
 	b, _ := json.Marshal(obj.data)
 	obj.mux.RUnlock()
 
+	send := string(b)
+	// Wrap request body if write_object_key is configured
+	send, err := obj.wrapRequestBody(ctx, send)
+	if err != nil {
+		return err
+	}
+
 	postPath := obj.createPath
 	if obj.queryString != "" {
 		tflog.Debug(ctx, "Adding query string", map[string]interface{}{"query_string": obj.queryString})
 		postPath = fmt.Sprintf("%s?%s", obj.createPath, obj.queryString)
 	}
 
-	resultString, _, err := obj.apiClient.SendRequest(ctx, obj.createMethod, strings.Replace(postPath, "{id}", obj.ID, -1), string(b), obj.debug)
+	resultString, _, err := obj.apiClient.SendRequest(ctx, obj.createMethod, strings.Replace(postPath, "{id}", obj.ID, -1), send, obj.debug)
 	if err != nil {
 		return err
 	}
@@ -476,6 +490,12 @@ func (obj *APIObject) UpdateObject(ctx context.Context) error {
 		send = string(b)
 	}
 	obj.mux.RUnlock()
+
+	// Wrap request body if write_object_key is configured
+	send, err := obj.wrapRequestBody(ctx, send)
+	if err != nil {
+		return err
+	}
 
 	putPath := obj.updatePath
 	if obj.queryString != "" {
@@ -642,6 +662,47 @@ func (obj *APIObject) GetApiResponse() string {
 // GetReadObjectKey returns the read_object_key configuration value
 func (obj *APIObject) GetReadObjectKey() string {
 	return obj.readObjectKey
+}
+
+// GetWriteObjectKey returns the write_object_key configuration value
+func (obj *APIObject) GetWriteObjectKey() string {
+	return obj.writeObjectKey
+}
+
+// wrapRequestBody wraps a JSON string under write_object_key if configured.
+// For example, with write_object_key="entry" and data=`{"id":"1","name":"foo"}`,
+// returns `{"entry":{"id":"1","name":"foo"}}`.
+// Supports nested paths with '/' delimiter (e.g., "request/data").
+func (obj *APIObject) wrapRequestBody(ctx context.Context, data string) (string, error) {
+	if obj.writeObjectKey == "" {
+		return data, nil
+	}
+
+	tflog.Debug(ctx, "Wrapping request body", map[string]interface{}{"write_object_key": obj.writeObjectKey})
+
+	// Parse the original data
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(data), &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse data for write_object_key wrapping: %w", err)
+	}
+
+	// Build nested wrapper from path segments (e.g., "request/data" → {"request": {"data": ...}})
+	parts := strings.Split(obj.writeObjectKey, "/")
+	wrapped := parsed
+	for i := len(parts) - 1; i >= 0; i-- {
+		if parts[i] == "" {
+			continue
+		}
+		wrapped = map[string]interface{}{parts[i]: wrapped}
+	}
+
+	result, err := json.Marshal(wrapped)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal wrapped data: %w", err)
+	}
+
+	tflog.Debug(ctx, "Successfully wrapped request body", map[string]interface{}{"write_object_key": obj.writeObjectKey})
+	return string(result), nil
 }
 
 // GetReadSearch returns a copy of the read_search configuration

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -37,6 +37,8 @@ type APIObjectOpts struct {
 	ID             string
 	IDAttribute    string
 	Data           string
+	ValidatePath   string
+	ValidateMethod string
 }
 
 // APIObject is the state holding struct for a restapi_object resource
@@ -56,6 +58,8 @@ type APIObject struct {
 	queryString    string
 	debug          bool
 	readSearch     map[string]string
+	validatePath   string
+	validateMethod string
 	ID             string
 	IDAttribute    string
 
@@ -144,6 +148,8 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 		readSearch:     opts.ReadSearch,
 		readObjectKey:  opts.ReadObjectKey,
 		writeObjectKey: opts.WriteObjectKey,
+		validatePath:   opts.ValidatePath,
+		validateMethod: opts.ValidateMethod,
 		ID:             opts.ID,
 		IDAttribute:    opts.IDAttribute,
 		data:           make(map[string]interface{}),
@@ -667,6 +673,58 @@ func (obj *APIObject) GetReadObjectKey() string {
 // GetWriteObjectKey returns the write_object_key configuration value
 func (obj *APIObject) GetWriteObjectKey() string {
 	return obj.writeObjectKey
+}
+
+// GetValidatePath returns the validate_path configuration value
+func (obj *APIObject) GetValidatePath() string {
+	return obj.validatePath
+}
+
+// GetValidateMethod returns the validate_method configuration value
+func (obj *APIObject) GetValidateMethod() string {
+	return obj.validateMethod
+}
+
+// ValidateObject calls the configured validate_path endpoint with the object's data.
+// It is intended to be called during plan to catch invalid configurations before apply.
+// A non-2xx response is treated as a validation failure and the error is returned.
+// If validate_path is not set, ValidateObject is a no-op and returns nil.
+func (obj *APIObject) ValidateObject(ctx context.Context) error {
+	if obj.validatePath == "" {
+		return nil
+	}
+
+	method := obj.validateMethod
+	if method == "" {
+		method = "POST"
+	}
+
+	obj.mux.RLock()
+	b, _ := json.Marshal(obj.data)
+	obj.mux.RUnlock()
+
+	send := string(b)
+	// Wrap request body if write_object_key is configured — same behaviour as CreateObject.
+	var err error
+	send, err = obj.wrapRequestBody(ctx, send)
+	if err != nil {
+		return fmt.Errorf("validate: failed to wrap request body: %w", err)
+	}
+
+	tflog.Debug(ctx, "Calling validate endpoint", map[string]interface{}{
+		"method":        method,
+		"validate_path": obj.validatePath,
+	})
+
+	_, _, err = obj.apiClient.SendRequest(ctx, method, obj.validatePath, send, obj.debug)
+	if err != nil {
+		return fmt.Errorf("validate: API rejected configuration at %s: %w", obj.validatePath, err)
+	}
+
+	tflog.Debug(ctx, "Validate endpoint accepted configuration", map[string]interface{}{
+		"validate_path": obj.validatePath,
+	})
+	return nil
 }
 
 // wrapRequestBody wraps a JSON string under write_object_key if configured.

--- a/internal/apiclient/object_read_objectkey_test.go
+++ b/internal/apiclient/object_read_objectkey_test.go
@@ -1,0 +1,223 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestReadObject_ReadObjectKey tests the read_object_key extraction feature
+func TestReadObject_ReadObjectKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		readObjectKey  string
+		apiResponse    map[string]interface{}
+		expectedData   map[string]interface{}
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:          "simple_wrapper_extraction",
+			readObjectKey: "result",
+			apiResponse: map[string]interface{}{
+				"result": map[string]interface{}{
+					"id":   "test-123",
+					"name": "test-object",
+				},
+			},
+			expectedData: map[string]interface{}{
+				"id":   "test-123",
+				"name": "test-object",
+			},
+			expectError: false,
+		},
+		{
+			name:          "nested_path_extraction",
+			readObjectKey: "data/item",
+			apiResponse: map[string]interface{}{
+				"data": map[string]interface{}{
+					"item": map[string]interface{}{
+						"id":    "nested-456",
+						"value": "nested-data",
+					},
+				},
+			},
+			expectedData: map[string]interface{}{
+				"id":    "nested-456",
+				"value": "nested-data",
+			},
+			expectError: false,
+		},
+		{
+			name:          "no_extraction_empty_key",
+			readObjectKey: "",
+			apiResponse: map[string]interface{}{
+				"id":   "direct-789",
+				"name": "direct-object",
+			},
+			expectedData: map[string]interface{}{
+				"id":   "direct-789",
+				"name": "direct-object",
+			},
+			expectError: false,
+		},
+		{
+			name:          "error_key_not_found",
+			readObjectKey: "missing_key",
+			apiResponse: map[string]interface{}{
+				"result": map[string]interface{}{
+					"id": "test-123",
+				},
+			},
+			expectedData:  nil,
+			expectError:   true,
+			errorContains: "failed to extract read_object_key 'missing_key'",
+		},
+		{
+			name:          "deep_nested_path",
+			readObjectKey: "response/data/items",
+			apiResponse: map[string]interface{}{
+				"response": map[string]interface{}{
+					"data": map[string]interface{}{
+						"items": map[string]interface{}{
+							"id":   "deep-999",
+							"type": "nested",
+						},
+					},
+				},
+			},
+			expectedData: map[string]interface{}{
+				"id":   "deep-999",
+				"type": "nested",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(tt.apiResponse)
+			}))
+			defer server.Close()
+
+			// Create API client
+			client, err := NewAPIClient(&APIClientOpt{
+				URI:     server.URL,
+				Timeout: 2,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create API client: %v", err)
+			}
+
+			// Create API object with read_object_key
+			obj, err := NewAPIObject(client, &APIObjectOpts{
+				Path:          "/api/objects",
+				ReadObjectKey: tt.readObjectKey,
+				ID:            "test-id",
+				Data:          `{"id": "test-id"}`,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create API object: %v", err)
+			}
+
+			// Execute ReadObject
+			err = obj.ReadObject(context.Background())
+
+			// Verify error expectations
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("Expected error but got none")
+				}
+				if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
+					t.Fatalf("Expected error to contain '%s', got: %v", tt.errorContains, err)
+				}
+				return
+			}
+
+			// Verify no error
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Verify extracted data matches expected
+			actualData := obj.GetApiData()
+			if tt.expectedData != nil {
+				for k, expectedValue := range tt.expectedData {
+					actualValue, exists := actualData[k]
+					if !exists {
+						t.Errorf("Expected key '%s' not found in api_data", k)
+					} else if actualValue != expectedValue {
+						t.Errorf("Key '%s': expected '%v', got '%v'", k, expectedValue, actualValue)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestReadObject_ReadObjectKeyWithXSSIPrefix tests that both xssi_prefix and read_object_key work together
+func TestReadObject_ReadObjectKeyWithXSSIPrefix(t *testing.T) {
+	// Create test server that returns XSSI-prefixed wrapped response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// XSSI prefix + wrapped response
+		w.Write([]byte(")]}'\n{\"data\": {\"id\": \"xssi-123\", \"value\": \"protected\"}}"))
+	}))
+	defer server.Close()
+
+	// Create API client with XSSI prefix configured
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:        server.URL,
+		Timeout:    2,
+		XSSIPrefix: ")]}'\n",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	// Create API object with read_object_key
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:          "/api/objects",
+		ReadObjectKey: "data", // Should extract after XSSI strip
+		ID:            "xssi-123",
+		Data:          `{"id": "xssi-123"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	// Execute ReadObject
+	err = obj.ReadObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify extracted data (not wrapped, XSSI stripped)
+	apiData := obj.GetApiData()
+	if apiData["id"] != "xssi-123" {
+		t.Errorf("Expected id 'xssi-123', got: %v", apiData["id"])
+	}
+	if apiData["value"] != "protected" {
+		t.Errorf("Expected value 'protected', got: %v", apiData["value"])
+	}
+}
+
+// Helper function for string contains check
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && indexOf(s, substr) >= 0))
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/apiclient/object_read_objectkey_test.go
+++ b/internal/apiclient/object_read_objectkey_test.go
@@ -11,12 +11,12 @@ import (
 // TestReadObject_ReadObjectKey tests the read_object_key extraction feature
 func TestReadObject_ReadObjectKey(t *testing.T) {
 	tests := []struct {
-		name           string
-		readObjectKey  string
-		apiResponse    map[string]interface{}
-		expectedData   map[string]interface{}
-		expectError    bool
-		errorContains  string
+		name          string
+		readObjectKey string
+		apiResponse   map[string]interface{}
+		expectedData  map[string]interface{}
+		expectError   bool
+		errorContains string
 	}{
 		{
 			name:          "simple_wrapper_extraction",

--- a/internal/apiclient/object_validate_test.go
+++ b/internal/apiclient/object_validate_test.go
@@ -1,0 +1,190 @@
+package apiclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newValidateTestClient creates an APIClient pointed at svr.URL.
+func newValidateTestClient(t *testing.T, svrURL string) *APIClient {
+	t.Helper()
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:     svrURL,
+		Timeout: 5,
+	})
+	require.NoError(t, err)
+	return client
+}
+
+// TestValidateObject_NoValidatePath verifies ValidateObject is a no-op when validate_path is empty.
+func TestValidateObject_NoValidatePath(t *testing.T) {
+	ctx := context.Background()
+
+	called := false
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path: "/objects",
+		Data: `{"id":"1","name":"test"}`,
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.NoError(t, err, "ValidateObject should be a no-op when validate_path is empty")
+	assert.False(t, called, "No HTTP request should be made when validate_path is empty")
+}
+
+// TestValidateObject_Success verifies a 200 response from validate_path passes.
+func TestValidateObject_Success(t *testing.T) {
+	ctx := context.Background()
+
+	var receivedMethod, receivedPath, receivedBody string
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedPath = r.URL.Path
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		receivedBody = string(buf)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:         "/objects",
+		Data:         `{"id":"1","name":"test"}`,
+		ValidatePath: "/objects/validate",
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.NoError(t, err, "ValidateObject should succeed on 200")
+	assert.Equal(t, "POST", receivedMethod, "Default method should be POST")
+	assert.Equal(t, "/objects/validate", receivedPath)
+	assert.Contains(t, receivedBody, `"name":"test"`, "Data should be sent in the request body")
+}
+
+// TestValidateObject_CustomMethod verifies that validate_method overrides the default POST.
+func TestValidateObject_CustomMethod(t *testing.T) {
+	ctx := context.Background()
+
+	var receivedMethod string
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/objects",
+		Data:           `{"id":"1"}`,
+		ValidatePath:   "/objects/validate",
+		ValidateMethod: "PUT",
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "PUT", receivedMethod, "ValidateMethod should override default POST")
+}
+
+// TestValidateObject_APIRejectsConfig verifies a 4xx response fails the validation with an error.
+func TestValidateObject_APIRejectsConfig(t *testing.T) {
+	ctx := context.Background()
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errorMessage":"tableName is required"}`, http.StatusBadRequest)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:         "/objects",
+		Data:         `{"name":"bad"}`,
+		ValidatePath: "/objects/validate",
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.Error(t, err, "ValidateObject should return an error on 4xx response")
+	assert.Contains(t, err.Error(), "/objects/validate", "Error should mention the validate path")
+}
+
+// TestValidateObject_ServerError verifies a 5xx response also fails validation.
+func TestValidateObject_ServerError(t *testing.T) {
+	ctx := context.Background()
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:         "/objects",
+		Data:         `{"id":"1"}`,
+		ValidatePath: "/objects/validate",
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.Error(t, err, "ValidateObject should return an error on 5xx response")
+}
+
+// TestValidateObject_WithWriteObjectKey verifies write_object_key wrapping also applies to validate.
+func TestValidateObject_WithWriteObjectKey(t *testing.T) {
+	ctx := context.Background()
+
+	var receivedBody string
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 1024)
+		n, _ := r.Body.Read(buf)
+		receivedBody = string(buf[:n])
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/objects",
+		Data:           `{"id":"1","name":"test"}`,
+		ValidatePath:   "/objects/validate",
+		WriteObjectKey: "entry",
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.NoError(t, err)
+	assert.Contains(t, receivedBody, `"entry"`, "write_object_key wrapping should apply to validate request body")
+}
+
+// TestValidateObject_GettersReturnConfiguredValues verifies accessor methods.
+func TestValidateObject_GettersReturnConfiguredValues(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/objects",
+		Data:           `{"id":"1"}`,
+		ValidatePath:   "/objects/validate",
+		ValidateMethod: "POST",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/objects/validate", obj.GetValidatePath())
+	assert.Equal(t, "POST", obj.GetValidateMethod())
+}

--- a/internal/apiclient/object_write_objectkey_test.go
+++ b/internal/apiclient/object_write_objectkey_test.go
@@ -1,0 +1,361 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestCreateObject_WriteObjectKey tests that write_object_key wraps POST request bodies
+func TestCreateObject_WriteObjectKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		writeObjectKey string
+		data           string
+		expectedBody   map[string]interface{}
+	}{
+		{
+			name:           "simple_wrapping",
+			writeObjectKey: "entry",
+			data:           `{"id": "test-1", "name": "foo"}`,
+			expectedBody: map[string]interface{}{
+				"entry": map[string]interface{}{
+					"id":   "test-1",
+					"name": "foo",
+				},
+			},
+		},
+		{
+			name:           "nested_wrapping",
+			writeObjectKey: "request/data",
+			data:           `{"id": "test-2", "value": "bar"}`,
+			expectedBody: map[string]interface{}{
+				"request": map[string]interface{}{
+					"data": map[string]interface{}{
+						"id":    "test-2",
+						"value": "bar",
+					},
+				},
+			},
+		},
+		{
+			name:           "no_wrapping_empty_key",
+			writeObjectKey: "",
+			data:           `{"id": "test-3", "name": "baz"}`,
+			expectedBody: map[string]interface{}{
+				"id":   "test-3",
+				"name": "baz",
+			},
+		},
+		{
+			name:           "deep_nested_wrapping",
+			writeObjectKey: "api/v2/payload",
+			data:           `{"id": "test-4", "config": {"enabled": true}}`,
+			expectedBody: map[string]interface{}{
+				"api": map[string]interface{}{
+					"v2": map[string]interface{}{
+						"payload": map[string]interface{}{
+							"id": "test-4",
+							"config": map[string]interface{}{
+								"enabled": true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var receivedBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "POST" {
+					body, _ := io.ReadAll(r.Body)
+					json.Unmarshal(body, &receivedBody)
+				}
+				// Return the unwrapped object (as if API strips the wrapper)
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":   "test-1",
+					"name": "foo",
+				})
+			}))
+			defer server.Close()
+
+			client, err := NewAPIClient(&APIClientOpt{
+				URI:                server.URL,
+				Timeout:            2,
+				WriteReturnsObject: true,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create API client: %v", err)
+			}
+
+			obj, err := NewAPIObject(client, &APIObjectOpts{
+				Path:           "/api/objects",
+				WriteObjectKey: tt.writeObjectKey,
+				Data:           tt.data,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create API object: %v", err)
+			}
+
+			err = obj.CreateObject(context.Background())
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Verify the request body was wrapped correctly
+			expectedJSON, _ := json.Marshal(tt.expectedBody)
+			receivedJSON, _ := json.Marshal(receivedBody)
+
+			var expectedNorm, receivedNorm interface{}
+			json.Unmarshal(expectedJSON, &expectedNorm)
+			json.Unmarshal(receivedJSON, &receivedNorm)
+
+			expectedStr, _ := json.Marshal(expectedNorm)
+			receivedStr, _ := json.Marshal(receivedNorm)
+
+			if string(expectedStr) != string(receivedStr) {
+				t.Errorf("Request body mismatch.\nExpected: %s\nReceived: %s", string(expectedStr), string(receivedStr))
+			}
+		})
+	}
+}
+
+// TestUpdateObject_WriteObjectKey tests that write_object_key wraps PUT request bodies
+func TestUpdateObject_WriteObjectKey(t *testing.T) {
+	var receivedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":   "update-1",
+			"name": "updated",
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:                server.URL,
+		Timeout:            2,
+		WriteReturnsObject: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/api/objects",
+		WriteObjectKey: "entry",
+		ID:             "update-1",
+		Data:           `{"id": "update-1", "name": "updated"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	err = obj.UpdateObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify the PUT body was wrapped under "entry"
+	entry, ok := receivedBody["entry"]
+	if !ok {
+		t.Fatalf("Expected request body to have 'entry' key, got: %v", receivedBody)
+	}
+	entryMap, ok := entry.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected 'entry' to be a map, got: %T", entry)
+	}
+	if entryMap["id"] != "update-1" {
+		t.Errorf("Expected id 'update-1', got: %v", entryMap["id"])
+	}
+	if entryMap["name"] != "updated" {
+		t.Errorf("Expected name 'updated', got: %v", entryMap["name"])
+	}
+}
+
+// TestWriteObjectKey_WithReadObjectKey tests that both directions work together:
+// write_object_key wraps POST/PUT bodies, read_object_key unwraps GET responses
+func TestWriteObjectKey_WithReadObjectKey(t *testing.T) {
+	var createBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case "POST":
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &createBody)
+			// API responds with wrapped response
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":   "combo-1",
+				"name": "combo-test",
+			})
+		case "GET":
+			// API returns wrapped GET response
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"result": map[string]interface{}{
+					"id":   "combo-1",
+					"name": "combo-test",
+				},
+				"success": true,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:                 server.URL,
+		Timeout:             2,
+		CreateReturnsObject: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/api/objects",
+		WriteObjectKey: "entry",
+		ReadObjectKey:  "result",
+		Data:           `{"id": "combo-1", "name": "combo-test"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	// Test CREATE: body should be wrapped
+	err = obj.CreateObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected create error: %v", err)
+	}
+
+	entry, ok := createBody["entry"]
+	if !ok {
+		t.Fatalf("POST body should have 'entry' wrapper, got: %v", createBody)
+	}
+	entryMap := entry.(map[string]interface{})
+	if entryMap["name"] != "combo-test" {
+		t.Errorf("POST body entry.name should be 'combo-test', got: %v", entryMap["name"])
+	}
+
+	// Test READ: response should be unwrapped
+	err = obj.ReadObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected read error: %v", err)
+	}
+
+	apiData := obj.GetApiData()
+	if apiData["id"] != "combo-1" {
+		t.Errorf("Expected id 'combo-1' after unwrapping, got: %v", apiData["id"])
+	}
+	if apiData["name"] != "combo-test" {
+		t.Errorf("Expected name 'combo-test' after unwrapping, got: %v", apiData["name"])
+	}
+	// Should NOT have 'success' or 'result' keys (they were stripped by read_object_key)
+	if _, exists := apiData["success"]; exists {
+		t.Error("Should not have 'success' key after read_object_key extraction")
+	}
+}
+
+// TestWriteObjectKey_CascadeFromProvider tests that write_object_key falls back to client-level config
+func TestWriteObjectKey_CascadeFromProvider(t *testing.T) {
+	var receivedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "cascade-1", "name": "test"})
+	}))
+	defer server.Close()
+
+	// Set write_object_key on the CLIENT (simulating provider-level config)
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:                server.URL,
+		Timeout:            2,
+		WriteReturnsObject: true,
+		WriteObjectKey:     "wrapper",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	// Object does NOT set write_object_key — should inherit from client
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path: "/api/objects",
+		Data: `{"id": "cascade-1", "name": "test"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	err = obj.CreateObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if _, ok := receivedBody["wrapper"]; !ok {
+		t.Fatalf("Expected client-level write_object_key 'wrapper' to be applied, got: %v", receivedBody)
+	}
+}
+
+// TestWriteObjectKey_ResourceOverridesProvider tests that resource-level write_object_key overrides provider
+func TestWriteObjectKey_ResourceOverridesProvider(t *testing.T) {
+	var receivedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &receivedBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "override-1", "name": "test"})
+	}))
+	defer server.Close()
+
+	// Provider sets "provider_wrapper"
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:                server.URL,
+		Timeout:            2,
+		WriteReturnsObject: true,
+		WriteObjectKey:     "provider_wrapper",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API client: %v", err)
+	}
+
+	// Resource overrides with "resource_wrapper"
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/api/objects",
+		WriteObjectKey: "resource_wrapper",
+		Data:           `{"id": "override-1", "name": "test"}`,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create API object: %v", err)
+	}
+
+	err = obj.CreateObject(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if _, ok := receivedBody["resource_wrapper"]; !ok {
+		t.Fatalf("Expected resource-level 'resource_wrapper' to override provider, got: %v", receivedBody)
+	}
+	if _, ok := receivedBody["provider_wrapper"]; ok {
+		t.Fatal("Provider-level 'provider_wrapper' should NOT be present when resource overrides")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -184,7 +184,7 @@ func (p *RestAPIProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			},
 			"read_object_key": schema.StringAttribute{
 				Optional:    true,
-				Description: "When set, this key will be used to extract an object from GET responses. For example, if the API wraps responses like {\"REALTIME\": {...actual object...}}, set this to 'REALTIME' to extract the inner object for state storage. Supports nested paths: 'data/items/0', 'result/resource'. This value may also be set via the REST_API_READ_OBJECT_KEY environment variable.",
+				Description: "When set, this key will be used to extract an object from GET responses. Useful for APIs that wrap responses in an envelope (e.g., {\"result\": {...}}, {\"data\": {...}}). Set to the wrapper key to extract the inner object before state comparison. Supports nested paths with '/' delimiter (e.g., 'data/items', 'response/result'). This value may also be set via the REST_API_READ_OBJECT_KEY environment variable.",
 			},
 			"rate_limit": schema.Float64Attribute{
 				Optional:    true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -44,6 +44,7 @@ type RestAPIProviderModel struct {
 	CreateReturnsObject types.Bool            `tfsdk:"create_returns_object"`
 	XSSIPrefix          types.String          `tfsdk:"xssi_prefix"`
 	ReadObjectKey       types.String          `tfsdk:"read_object_key"`
+	WriteObjectKey      types.String          `tfsdk:"write_object_key"`
 	RateLimit           types.Float64         `tfsdk:"rate_limit"`
 	TestPath            types.String          `tfsdk:"test_path"`
 	Debug               types.Bool            `tfsdk:"debug"`
@@ -185,6 +186,10 @@ func (p *RestAPIProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			"read_object_key": schema.StringAttribute{
 				Optional:    true,
 				Description: "When set, this key will be used to extract an object from GET responses. Useful for APIs that wrap responses in an envelope (e.g., {\"result\": {...}}, {\"data\": {...}}). Set to the wrapper key to extract the inner object before state comparison. Supports nested paths with '/' delimiter (e.g., 'data/items', 'response/result'). This value may also be set via the REST_API_READ_OBJECT_KEY environment variable.",
+			},
+			"write_object_key": schema.StringAttribute{
+				Optional:    true,
+				Description: "When set, POST and PUT request bodies will be wrapped under this key before sending to the API. Useful for APIs that require request data to be nested in an envelope (e.g., {\"entry\": {...}}, {\"request\": {...}}). Supports nested paths with '/' delimiter (e.g., 'request/data'). This value may also be set via the REST_API_WRITE_OBJECT_KEY environment variable.",
 			},
 			"rate_limit": schema.Float64Attribute{
 				Optional:    true,
@@ -335,6 +340,7 @@ func (p *RestAPIProvider) Configure(ctx context.Context, req provider.ConfigureR
 		CreateReturnsObject: existingOrEnvOrDefaultBool(&resp.Diagnostics, "create_returns_object", data.CreateReturnsObject, "REST_API_CRO", false, false),
 		XSSIPrefix:          existingOrEnvOrDefaultString(&resp.Diagnostics, "xssi_prefix", data.XSSIPrefix, "REST_API_XSSI_PREFIX", "", false),
 		ReadObjectKey:       existingOrEnvOrDefaultString(&resp.Diagnostics, "read_object_key", data.ReadObjectKey, "REST_API_READ_OBJECT_KEY", "", false),
+		WriteObjectKey:      existingOrEnvOrDefaultString(&resp.Diagnostics, "write_object_key", data.WriteObjectKey, "REST_API_WRITE_OBJECT_KEY", "", false),
 		RateLimit:           existingOrEnvOrDefaultFloat(&resp.Diagnostics, "rate_limit", data.RateLimit, "REST_API_RATE_LIMIT", math.MaxFloat64, false),
 		Debug:               existingOrEnvOrDefaultBool(&resp.Diagnostics, "debug", data.Debug, "REST_API_DEBUG", false, false),
 		CreateMethod:        existingOrEnvOrDefaultString(&resp.Diagnostics, "create_method", data.CreateMethod, "REST_API_CREATE_METHOD", "POST", false),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,6 +43,7 @@ type RestAPIProviderModel struct {
 	WriteReturnsObject  types.Bool            `tfsdk:"write_returns_object"`
 	CreateReturnsObject types.Bool            `tfsdk:"create_returns_object"`
 	XSSIPrefix          types.String          `tfsdk:"xssi_prefix"`
+	ReadObjectKey       types.String          `tfsdk:"read_object_key"`
 	RateLimit           types.Float64         `tfsdk:"rate_limit"`
 	TestPath            types.String          `tfsdk:"test_path"`
 	Debug               types.Bool            `tfsdk:"debug"`
@@ -180,6 +181,10 @@ func (p *RestAPIProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			"xssi_prefix": schema.StringAttribute{
 				Optional:    true,
 				Description: "Trim the xssi prefix from response string, if present, before parsing.",
+			},
+			"read_object_key": schema.StringAttribute{
+				Optional:    true,
+				Description: "When set, this key will be used to extract an object from GET responses. For example, if the API wraps responses like {\"REALTIME\": {...actual object...}}, set this to 'REALTIME' to extract the inner object for state storage. Supports nested paths: 'data/items/0', 'result/resource'. This value may also be set via the REST_API_READ_OBJECT_KEY environment variable.",
 			},
 			"rate_limit": schema.Float64Attribute{
 				Optional:    true,
@@ -329,6 +334,7 @@ func (p *RestAPIProvider) Configure(ctx context.Context, req provider.ConfigureR
 		WriteReturnsObject:  existingOrEnvOrDefaultBool(&resp.Diagnostics, "write_returns_object", data.WriteReturnsObject, "REST_API_WRO", false, false),
 		CreateReturnsObject: existingOrEnvOrDefaultBool(&resp.Diagnostics, "create_returns_object", data.CreateReturnsObject, "REST_API_CRO", false, false),
 		XSSIPrefix:          existingOrEnvOrDefaultString(&resp.Diagnostics, "xssi_prefix", data.XSSIPrefix, "REST_API_XSSI_PREFIX", "", false),
+		ReadObjectKey:       existingOrEnvOrDefaultString(&resp.Diagnostics, "read_object_key", data.ReadObjectKey, "REST_API_READ_OBJECT_KEY", "", false),
 		RateLimit:           existingOrEnvOrDefaultFloat(&resp.Diagnostics, "rate_limit", data.RateLimit, "REST_API_RATE_LIMIT", math.MaxFloat64, false),
 		Debug:               existingOrEnvOrDefaultBool(&resp.Diagnostics, "debug", data.Debug, "REST_API_DEBUG", false, false),
 		CreateMethod:        existingOrEnvOrDefaultString(&resp.Diagnostics, "create_method", data.CreateMethod, "REST_API_CREATE_METHOD", "POST", false),

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -214,7 +214,7 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 				},
 			},
 			"read_object_key": schema.StringAttribute{
-				Description: "Defaults to `read_object_key` set on the provider. Allows per-resource override. When set, this key is used to extract an object from GET responses. For example, if the API wraps responses like {\"REALTIME\": {...}}, set this to 'REALTIME'. Supports nested paths like 'data/items/0'.",
+				Description: "Defaults to `read_object_key` set on the provider. Allows per-resource override. When set, this key is used to extract an object from GET responses. Useful when the API wraps the response in an envelope. Supports nested paths with '/' delimiter (e.g., 'data/item', 'response/0').",
 				Optional:    true,
 				Computed:    true, // CRITICAL: Store in state to persist through Read cycles
 			},

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -52,6 +52,7 @@ type RestAPIObjectResourceModel struct {
 	IgnoreAllServerChanges types.Bool           `tfsdk:"ignore_all_server_changes"`
 	IgnoreServerAdditions  types.Bool           `tfsdk:"ignore_server_additions"`
 	ReadObjectKey          types.String         `tfsdk:"read_object_key"`
+	WriteObjectKey         types.String         `tfsdk:"write_object_key"`
 
 	ID             types.String `tfsdk:"id"`
 	APIData        types.Map    `tfsdk:"api_data"`
@@ -217,6 +218,11 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 				Description: "Defaults to `read_object_key` set on the provider. Allows per-resource override. When set, this key is used to extract an object from GET responses. Useful when the API wraps the response in an envelope. Supports nested paths with '/' delimiter (e.g., 'data/item', 'response/0').",
 				Optional:    true,
 				Computed:    true, // CRITICAL: Store in state to persist through Read cycles
+			},
+			"write_object_key": schema.StringAttribute{
+				Description: "Defaults to `write_object_key` set on the provider. Allows per-resource override. When set, POST and PUT request bodies are wrapped under this key before sending. Useful when the API requires data nested in an envelope (e.g., 'entry', 'request/data').",
+				Optional:    true,
+				Computed:    true, // Store in state to persist through Read cycles
 			},
 
 			"create_response": schema.StringAttribute{
@@ -704,8 +710,9 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		DestroyMethod: existingOrProviderOrDefaultString(model.DestroyMethod, client.Opts.DestroyMethod, "DELETE"),
 		DestroyData:   model.DestroyData.ValueString(),
 
-		QueryString:   existingOrDefaultString(model.QueryString, ""),
-		ReadObjectKey: existingOrProviderOrDefaultString(model.ReadObjectKey, client.Opts.ReadObjectKey, ""),
+		QueryString:    existingOrDefaultString(model.QueryString, ""),
+		ReadObjectKey:  existingOrProviderOrDefaultString(model.ReadObjectKey, client.Opts.ReadObjectKey, ""),
+		WriteObjectKey: existingOrProviderOrDefaultString(model.WriteObjectKey, client.Opts.WriteObjectKey, ""),
 	}
 
 	// Wire up read_search if configured
@@ -746,7 +753,8 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 func setResourceModelData(ctx context.Context, obj *apiclient.APIObject, data *RestAPIObjectResourceModel, diag *diag.Diagnostics) {
 	data.ID = types.StringValue(obj.ID)
 	data.APIResponse = types.StringValue(obj.GetApiResponse())
-	data.ReadObjectKey = types.StringValue(obj.GetReadObjectKey()) // Store resolved value in state
+	data.ReadObjectKey = types.StringValue(obj.GetReadObjectKey())   // Store resolved value in state
+	data.WriteObjectKey = types.StringValue(obj.GetWriteObjectKey()) // Store resolved value in state
 	v, d := types.MapValueFrom(ctx, types.StringType, obj.GetApiData())
 	data.APIData = v
 	diag.Append(d...)

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -51,6 +51,7 @@ type RestAPIObjectResourceModel struct {
 	IgnoreChangesTo        types.List           `tfsdk:"ignore_changes_to"`
 	IgnoreAllServerChanges types.Bool           `tfsdk:"ignore_all_server_changes"`
 	IgnoreServerAdditions  types.Bool           `tfsdk:"ignore_server_additions"`
+	ReadObjectKey          types.String         `tfsdk:"read_object_key"`
 
 	ID             types.String `tfsdk:"id"`
 	APIData        types.Map    `tfsdk:"api_data"`
@@ -211,6 +212,11 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 						CustomType:  jsontypes.NormalizedType{},
 					},
 				},
+			},
+			"read_object_key": schema.StringAttribute{
+				Description: "Defaults to `read_object_key` set on the provider. Allows per-resource override. When set, this key is used to extract an object from GET responses. For example, if the API wraps responses like {\"REALTIME\": {...}}, set this to 'REALTIME'. Supports nested paths like 'data/items/0'.",
+				Optional:    true,
+				Computed:    true, // CRITICAL: Store in state to persist through Read cycles
 			},
 
 			"create_response": schema.StringAttribute{
@@ -698,7 +704,8 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		DestroyMethod: existingOrProviderOrDefaultString(model.DestroyMethod, client.Opts.DestroyMethod, "DELETE"),
 		DestroyData:   model.DestroyData.ValueString(),
 
-		QueryString: existingOrDefaultString(model.QueryString, ""),
+		QueryString:   existingOrDefaultString(model.QueryString, ""),
+		ReadObjectKey: existingOrProviderOrDefaultString(model.ReadObjectKey, client.Opts.ReadObjectKey, ""),
 	}
 
 	// Wire up read_search if configured
@@ -739,6 +746,7 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 func setResourceModelData(ctx context.Context, obj *apiclient.APIObject, data *RestAPIObjectResourceModel, diag *diag.Diagnostics) {
 	data.ID = types.StringValue(obj.ID)
 	data.APIResponse = types.StringValue(obj.GetApiResponse())
+	data.ReadObjectKey = types.StringValue(obj.GetReadObjectKey()) // Store resolved value in state
 	v, d := types.MapValueFrom(ctx, types.StringType, obj.GetApiData())
 	data.APIData = v
 	diag.Append(d...)

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -22,6 +22,7 @@ import (
 var _ resource.Resource = &RestAPIObjectResource{}
 var _ resource.ResourceWithImportState = &RestAPIObjectResource{}
 var _ resource.ResourceWithModifyPlan = &RestAPIObjectResource{}
+var _ resource.ResourceWithConfigValidators = &RestAPIObjectResource{}
 
 type RestAPIObjectResource struct {
 	object       *restapi.APIObject
@@ -53,6 +54,8 @@ type RestAPIObjectResourceModel struct {
 	IgnoreServerAdditions  types.Bool           `tfsdk:"ignore_server_additions"`
 	ReadObjectKey          types.String         `tfsdk:"read_object_key"`
 	WriteObjectKey         types.String         `tfsdk:"write_object_key"`
+	ValidatePath           types.String         `tfsdk:"validate_path"`
+	ValidateMethod         types.String         `tfsdk:"validate_method"`
 
 	ID             types.String `tfsdk:"id"`
 	APIData        types.Map    `tfsdk:"api_data"`
@@ -223,6 +226,14 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 				Description: "Defaults to `write_object_key` set on the provider. Allows per-resource override. When set, POST and PUT request bodies are wrapped under this key before sending. Useful when the API requires data nested in an envelope (e.g., 'entry', 'request/data').",
 				Optional:    true,
 				Computed:    true, // Store in state to persist through Read cycles
+			},
+			"validate_path": schema.StringAttribute{
+				Description: "An optional endpoint path to call during `terraform plan` to pre-flight validate the resource configuration. The provider will send the object's `data` to this path using `validate_method` (default `POST`). A non-2xx response causes the plan to fail with the API's error message, surfacing configuration problems before apply.",
+				Optional:    true,
+			},
+			"validate_method": schema.StringAttribute{
+				Description: "The HTTP method used when calling `validate_path`. Defaults to `POST`.",
+				Optional:    true,
 			},
 
 			"create_response": schema.StringAttribute{
@@ -419,6 +430,70 @@ func (r *RestAPIObjectResource) Read(ctx context.Context, req resource.ReadReque
 	}
 	setResourceModelData(ctx, obj, &state, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// ConfigValidators returns validators that run during terraform plan.
+// When validate_path is set, it calls the configured endpoint with the object's data
+// and fails the plan if the API returns a non-2xx response.
+func (r *RestAPIObjectResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		&validatePathValidator{providerData: r.providerData},
+	}
+}
+
+// validatePathValidator is a resource.ConfigValidator that calls validate_path during plan.
+type validatePathValidator struct {
+	providerData *ProviderData
+}
+
+func (v *validatePathValidator) Description(_ context.Context) string {
+	return "Calls validate_path endpoint with the object data to pre-flight validate before apply."
+}
+
+func (v *validatePathValidator) MarkdownDescription(_ context.Context) string {
+	return "Calls `validate_path` endpoint with the object data to pre-flight validate before apply."
+}
+
+func (v *validatePathValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	// Provider not yet configured (e.g. during terraform validate without creds) — skip silently.
+	if v.providerData == nil {
+		return
+	}
+
+	var model RestAPIObjectResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// No validate_path set — nothing to do.
+	if model.ValidatePath.IsNull() || model.ValidatePath.IsUnknown() || model.ValidatePath.ValueString() == "" {
+		return
+	}
+
+	// data may be unknown during plan (e.g. depends on another resource) — skip.
+	if model.Data.IsNull() || model.Data.IsUnknown() {
+		return
+	}
+
+	client, err := v.providerData.GetClient()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to get API client for validation", err.Error())
+		return
+	}
+
+	obj, err := makeAPIObject(ctx, client, "", &model)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to build API object for validation", err.Error())
+		return
+	}
+
+	if err := obj.ValidateObject(ctx); err != nil {
+		resp.Diagnostics.AddError(
+			"API pre-flight validation failed",
+			fmt.Sprintf("The API rejected the configuration at validate_path %q: %s", model.ValidatePath.ValueString(), err.Error()),
+		)
+	}
 }
 
 func (r *RestAPIObjectResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
@@ -713,6 +788,8 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		QueryString:    existingOrDefaultString(model.QueryString, ""),
 		ReadObjectKey:  existingOrProviderOrDefaultString(model.ReadObjectKey, client.Opts.ReadObjectKey, ""),
 		WriteObjectKey: existingOrProviderOrDefaultString(model.WriteObjectKey, client.Opts.WriteObjectKey, ""),
+		ValidatePath:   existingOrDefaultString(model.ValidatePath, ""),
+		ValidateMethod: existingOrDefaultString(model.ValidateMethod, ""),
 	}
 
 	// Wire up read_search if configured

--- a/internal/provider/resource_api_object_validate_test.go
+++ b/internal/provider/resource_api_object_validate_test.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func jsonDecodeBody(r *http.Request, v interface{}) error {
+	return json.NewDecoder(r.Body).Decode(v)
+}
+
+// newValidateTestServer creates an httptest.Server that handles both the object CRUD path
+// (/api/objects) and a validation path (/api/objects/validate).
+// It calls validateFn for requests to the validate path.
+func newValidateTestServer(t *testing.T, validateFn http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Minimal object store for CRUD.
+	objects := map[string]map[string]interface{}{}
+
+	// Validate endpoint — delegates to the provided handler.
+	mux.HandleFunc("/api/objects/validate", validateFn)
+
+	// Object CRUD endpoint.
+	mux.HandleFunc("/api/objects/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			id := r.URL.Path[len("/api/objects/"):]
+			if obj, ok := objects[id]; ok {
+				writeJSON(w, obj)
+			} else {
+				http.NotFound(w, r)
+			}
+		case http.MethodDelete:
+			id := r.URL.Path[len("/api/objects/"):]
+			delete(objects, id)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/api/objects", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var obj map[string]interface{}
+		if err := jsonDecodeBody(r, &obj); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		id, _ := obj["id"].(string)
+		if id == "" {
+			id = "auto-id"
+			obj["id"] = id
+		}
+		objects[id] = obj
+		writeJSON(w, obj)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// TestAccRestApiObject_ValidatePath_Success tests that validate_path is called during plan
+// and a 200 response allows the plan and apply to succeed.
+func TestAccRestApiObject_ValidatePath_Success(t *testing.T) {
+	var validateCallCount int64
+
+	svr := newValidateTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&validateCallCount, 1)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "restapi" {
+  uri                  = %q
+  write_returns_object = true
+}
+
+resource "restapi_object" "test" {
+  path            = "/api/objects"
+  data            = jsonencode({ id = "val1", name = "test-validate" })
+  validate_path   = "/api/objects/validate"
+  validate_method = "POST"
+}
+`, svr.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("restapi_object.test", "id", "val1"),
+					resource.TestCheckResourceAttr("restapi_object.test", "validate_path", "/api/objects/validate"),
+					resource.TestCheckResourceAttr("restapi_object.test", "validate_method", "POST"),
+				),
+			},
+		},
+	})
+
+	if atomic.LoadInt64(&validateCallCount) == 0 {
+		t.Error("expected validate_path to be called at least once during plan, but it was not called")
+	}
+}
+
+// TestAccRestApiObject_ValidatePath_Failure tests that a non-2xx from validate_path
+// causes the plan to fail with an appropriate error.
+func TestAccRestApiObject_ValidatePath_Failure(t *testing.T) {
+	svr := newValidateTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errorMessage":"tableName is required"}`, http.StatusBadRequest)
+	})
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "restapi" {
+  uri                  = %q
+  write_returns_object = true
+}
+
+resource "restapi_object" "test" {
+  path          = "/api/objects"
+  data          = jsonencode({ id = "bad1", name = "bad-config" })
+  validate_path = "/api/objects/validate"
+}
+`, svr.URL),
+				ExpectError: regexp.MustCompile(`API pre-flight validation failed`),
+			},
+		},
+	})
+}
+
+// TestAccRestApiObject_NoValidatePath tests that omitting validate_path creates the resource normally.
+func TestAccRestApiObject_NoValidatePath(t *testing.T) {
+	svr := newValidateTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Should not be called.
+		t.Error("validate endpoint was called unexpectedly")
+		w.WriteHeader(http.StatusOK)
+	})
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "restapi" {
+  uri                  = %q
+  write_returns_object = true
+}
+
+resource "restapi_object" "test" {
+  path = "/api/objects"
+  data = jsonencode({ id = "novld1", name = "no-validate" })
+}
+`, svr.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("restapi_object.test", "id", "novld1"),
+					resource.TestCheckNoResourceAttr("restapi_object.test", "validate_path"),
+					resource.TestCheckNoResourceAttr("restapi_object.test", "validate_method"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds two new optional `restapi_object` resource attributes:

- **`validate_path`** — an endpoint to call during `terraform plan` with the object's `data`. A non-2xx response immediately fails the plan with the API's error message, surfacing configuration problems _before_ apply.
- **`validate_method`** — HTTP method for the validate call (default: `POST`).

Closes #362.

## Motivation

Many REST APIs expose a dedicated validation endpoint (e.g. `POST /resource/validate`) that performs a dry-run check without persisting anything. Without this feature, validation only surfaces at `apply` time when the API rejects the `POST`/`PUT`, which can cause partial applies where unrelated resources succeed but the invalid one fails.

## Usage

```hcl
resource "restapi_object" "example" {
  path            = "/tables"
  data            = jsonencode({ ... })
  validate_path   = "/tables/validate"
  validate_method = "POST"   # optional, defaults to POST
}
```

## Behaviour

- When `validate_path` is not set, the feature is a no-op — fully backward compatible.
- When `data` is unknown at plan time (e.g. depends on another resource), the validate call is skipped to avoid false failures.
- When `write_object_key` is configured, the same request-body wrapping that applies to `CreateObject` is also applied to the validate call.
- A non-2xx response produces a clear `API pre-flight validation failed` diagnostic that includes the validate path and the API's error body.

## Changes

| File | Change |
|---|---|
| `internal/apiclient/object.go` | Added `ValidatePath`/`ValidateMethod` to `APIObjectOpts` and `APIObject`; added `ValidateObject()` method; added `GetValidatePath()`/`GetValidateMethod()` accessors |
| `internal/provider/resource_api_object.go` | Added `validate_path`/`validate_method` schema attributes and model fields; implemented `resource.ResourceWithConfigValidators` via `validatePathValidator` |
| `internal/apiclient/object_validate_test.go` | 7 unit tests covering no-op, success, custom method, 4xx/5xx rejection, write_object_key wrapping, and accessors |
| `internal/provider/resource_api_object_validate_test.go` | 3 acceptance tests: success (validate called ≥1×), failure (plan error), no validate_path (no-op) |
| `test-integration/validate-lab0/validate_lab0.tf` | Example integration test config for APIs with a validate endpoint |

## Test results

```
ok  github.com/Mastercard/terraform-provider-restapi/internal/apiclient
ok  github.com/Mastercard/terraform-provider-restapi/internal/provider
```

All existing tests pass. `go vet` and `gofmt` clean.