### PR TITLE
feat: Add validate_path for pre-flight API validation during terraform plan

### DIFF
--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -32,9 +32,11 @@ type APIObjectOpts struct {
 	QueryString   string
 	Debug         bool
 	ReadSearch    map[string]string
-	ID            string
-	IDAttribute   string
-	Data          string
+	ID             string
+	IDAttribute    string
+	Data           string
+	ValidatePath   string
+	ValidateMethod string
 }
 
 // APIObject is the state holding struct for a restapi_object resource
@@ -51,9 +53,11 @@ type APIObject struct {
 	searchPath    string
 	queryString   string
 	debug         bool
-	readSearch    map[string]string
-	ID            string
-	IDAttribute   string
+	readSearch     map[string]string
+	validatePath   string
+	validateMethod string
+	ID             string
+	IDAttribute    string
 
 	// Set internally
 	mux         sync.RWMutex           // Protects data and apiData fields
@@ -129,9 +133,11 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 		searchPath:    opts.SearchPath,
 		queryString:   opts.QueryString,
 		debug:         opts.Debug,
-		readSearch:    opts.ReadSearch,
-		ID:            opts.ID,
-		IDAttribute:   opts.IDAttribute,
+		readSearch:     opts.ReadSearch,
+		validatePath:   opts.ValidatePath,
+		validateMethod: opts.ValidateMethod,
+		ID:             opts.ID,
+		IDAttribute:    opts.IDAttribute,
 		data:          make(map[string]interface{}),
 		readData:      nil,
 		updateData:    nil,
@@ -601,6 +607,52 @@ func (obj *APIObject) GetApiData() map[string]string {
 // GetApiResponse returns a copy of the raw API response from the APIObject
 func (obj *APIObject) GetApiResponse() string {
 	return obj.apiResponse
+}
+
+// GetValidatePath returns the validate_path configuration value
+func (obj *APIObject) GetValidatePath() string {
+	return obj.validatePath
+}
+
+// GetValidateMethod returns the validate_method configuration value
+func (obj *APIObject) GetValidateMethod() string {
+	return obj.validateMethod
+}
+
+// ValidateObject calls the configured validate_path endpoint with the object's data.
+// It is intended to be called during plan to catch invalid configurations before apply.
+// A non-2xx response is treated as a validation failure and the error is returned.
+// If validate_path is not set, ValidateObject is a no-op and returns nil.
+func (obj *APIObject) ValidateObject(ctx context.Context) error {
+	if obj.validatePath == "" {
+		return nil
+	}
+
+	method := obj.validateMethod
+	if method == "" {
+		method = "POST"
+	}
+
+	obj.mux.RLock()
+	b, _ := json.Marshal(obj.data)
+	obj.mux.RUnlock()
+
+	send := string(b)
+
+	tflog.Debug(ctx, "Calling validate endpoint", map[string]interface{}{
+		"method":        method,
+		"validate_path": obj.validatePath,
+	})
+
+	_, _, err := obj.apiClient.SendRequest(ctx, method, obj.validatePath, send, obj.debug)
+	if err != nil {
+		return fmt.Errorf("validate: API rejected configuration at %s: %w", obj.validatePath, err)
+	}
+
+	tflog.Debug(ctx, "Validate endpoint accepted configuration", map[string]interface{}{
+		"validate_path": obj.validatePath,
+	})
+	return nil
 }
 
 // GetReadSearch returns a copy of the read_search configuration

--- a/internal/apiclient/object_validate_test.go
+++ b/internal/apiclient/object_validate_test.go
@@ -1,0 +1,163 @@
+package apiclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newValidateTestClient creates an APIClient pointed at svr.URL.
+func newValidateTestClient(t *testing.T, svrURL string) *APIClient {
+	t.Helper()
+	client, err := NewAPIClient(&APIClientOpt{
+		URI:     svrURL,
+		Timeout: 5,
+	})
+	require.NoError(t, err)
+	return client
+}
+
+// TestValidateObject_NoValidatePath verifies ValidateObject is a no-op when validate_path is empty.
+func TestValidateObject_NoValidatePath(t *testing.T) {
+	ctx := context.Background()
+
+	called := false
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path: "/objects",
+		Data: `{"id":"1","name":"test"}`,
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.NoError(t, err, "ValidateObject should be a no-op when validate_path is empty")
+	assert.False(t, called, "No HTTP request should be made when validate_path is empty")
+}
+
+// TestValidateObject_Success verifies a 200 response from validate_path passes.
+func TestValidateObject_Success(t *testing.T) {
+	ctx := context.Background()
+
+	var receivedMethod, receivedPath, receivedBody string
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedPath = r.URL.Path
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		receivedBody = string(buf)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:         "/objects",
+		Data:         `{"id":"1","name":"test"}`,
+		ValidatePath: "/objects/validate",
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.NoError(t, err, "ValidateObject should succeed on 200")
+	assert.Equal(t, "POST", receivedMethod, "Default method should be POST")
+	assert.Equal(t, "/objects/validate", receivedPath)
+	assert.Contains(t, receivedBody, `"name":"test"`, "Data should be sent in the request body")
+}
+
+// TestValidateObject_CustomMethod verifies that validate_method overrides the default POST.
+func TestValidateObject_CustomMethod(t *testing.T) {
+	ctx := context.Background()
+
+	var receivedMethod string
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/objects",
+		Data:           `{"id":"1"}`,
+		ValidatePath:   "/objects/validate",
+		ValidateMethod: "PUT",
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "PUT", receivedMethod, "ValidateMethod should override default POST")
+}
+
+// TestValidateObject_APIRejectsConfig verifies a 4xx response fails the validation with an error.
+func TestValidateObject_APIRejectsConfig(t *testing.T) {
+	ctx := context.Background()
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errorMessage":"tableName is required"}`, http.StatusBadRequest)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:         "/objects",
+		Data:         `{"name":"bad"}`,
+		ValidatePath: "/objects/validate",
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.Error(t, err, "ValidateObject should return an error on 4xx response")
+	assert.Contains(t, err.Error(), "/objects/validate", "Error should mention the validate path")
+}
+
+// TestValidateObject_ServerError verifies a 5xx response also fails validation.
+func TestValidateObject_ServerError(t *testing.T) {
+	ctx := context.Background()
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:         "/objects",
+		Data:         `{"id":"1"}`,
+		ValidatePath: "/objects/validate",
+	})
+	require.NoError(t, err)
+
+	err = obj.ValidateObject(ctx)
+	assert.Error(t, err, "ValidateObject should return an error on 5xx response")
+}
+
+// TestValidateObject_GettersReturnConfiguredValues verifies accessor methods.
+func TestValidateObject_GettersReturnConfiguredValues(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	client := newValidateTestClient(t, svr.URL)
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:           "/objects",
+		Data:           `{"id":"1"}`,
+		ValidatePath:   "/objects/validate",
+		ValidateMethod: "POST",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/objects/validate", obj.GetValidatePath())
+	assert.Equal(t, "POST", obj.GetValidateMethod())
+}

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -22,6 +22,7 @@ import (
 var _ resource.Resource = &RestAPIObjectResource{}
 var _ resource.ResourceWithImportState = &RestAPIObjectResource{}
 var _ resource.ResourceWithModifyPlan = &RestAPIObjectResource{}
+var _ resource.ResourceWithConfigValidators = &RestAPIObjectResource{}
 
 type RestAPIObjectResource struct {
 	object       *restapi.APIObject
@@ -51,6 +52,8 @@ type RestAPIObjectResourceModel struct {
 	IgnoreChangesTo        types.List           `tfsdk:"ignore_changes_to"`
 	IgnoreAllServerChanges types.Bool           `tfsdk:"ignore_all_server_changes"`
 	IgnoreServerAdditions  types.Bool           `tfsdk:"ignore_server_additions"`
+	ValidatePath           types.String         `tfsdk:"validate_path"`
+	ValidateMethod         types.String         `tfsdk:"validate_method"`
 
 	ID             types.String `tfsdk:"id"`
 	APIData        types.Map    `tfsdk:"api_data"`
@@ -211,6 +214,15 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 						CustomType:  jsontypes.NormalizedType{},
 					},
 				},
+			},
+
+			"validate_path": schema.StringAttribute{
+				Description: "An optional endpoint path to call during `terraform plan` to pre-flight validate the resource configuration. The provider will send the object's `data` to this path using `validate_method` (default `POST`). A non-2xx response causes the plan to fail with the API's error message, surfacing configuration problems before apply.",
+				Optional:    true,
+			},
+			"validate_method": schema.StringAttribute{
+				Description: "The HTTP method used when calling `validate_path`. Defaults to `POST`.",
+				Optional:    true,
 			},
 
 			"create_response": schema.StringAttribute{
@@ -407,6 +419,67 @@ func (r *RestAPIObjectResource) Read(ctx context.Context, req resource.ReadReque
 	}
 	setResourceModelData(ctx, obj, &state, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// ConfigValidators returns validators that run during terraform plan.
+// When validate_path is set, it calls the configured endpoint with the object's data
+// and fails the plan if the API returns a non-2xx response.
+func (r *RestAPIObjectResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		&validatePathValidator{providerData: r.providerData},
+	}
+}
+
+// validatePathValidator calls validate_path during plan.
+type validatePathValidator struct {
+	providerData *ProviderData
+}
+
+func (v *validatePathValidator) Description(_ context.Context) string {
+	return "Calls validate_path endpoint with the object data to pre-flight validate before apply."
+}
+
+func (v *validatePathValidator) MarkdownDescription(_ context.Context) string {
+	return "Calls `validate_path` endpoint with the object data to pre-flight validate before apply."
+}
+
+func (v *validatePathValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	if v.providerData == nil {
+		return
+	}
+
+	var model RestAPIObjectResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if model.ValidatePath.IsNull() || model.ValidatePath.IsUnknown() || model.ValidatePath.ValueString() == "" {
+		return
+	}
+
+	if model.Data.IsNull() || model.Data.IsUnknown() {
+		return
+	}
+
+	client, err := v.providerData.GetClient()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to get API client for validation", err.Error())
+		return
+	}
+
+	obj, err := makeAPIObject(ctx, client, "", &model)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to build API object for validation", err.Error())
+		return
+	}
+
+	if err := obj.ValidateObject(ctx); err != nil {
+		resp.Diagnostics.AddError(
+			"API pre-flight validation failed",
+			fmt.Sprintf("The API rejected the configuration at validate_path %q: %s", model.ValidatePath.ValueString(), err.Error()),
+		)
+	}
 }
 
 func (r *RestAPIObjectResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
@@ -698,7 +771,9 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		DestroyMethod: existingOrProviderOrDefaultString(model.DestroyMethod, client.Opts.DestroyMethod, "DELETE"),
 		DestroyData:   model.DestroyData.ValueString(),
 
-		QueryString: existingOrDefaultString(model.QueryString, ""),
+		QueryString:    existingOrDefaultString(model.QueryString, ""),
+		ValidatePath:   existingOrDefaultString(model.ValidatePath, ""),
+		ValidateMethod: existingOrDefaultString(model.ValidateMethod, ""),
 	}
 
 	// Wire up read_search if configured

--- a/internal/provider/resource_api_object_validate_test.go
+++ b/internal/provider/resource_api_object_validate_test.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func jsonDecodeBody(r *http.Request, v interface{}) error {
+	return json.NewDecoder(r.Body).Decode(v)
+}
+
+// newValidateTestServer creates an httptest.Server that handles both the object CRUD path
+// (/api/objects) and a validation path (/api/objects/validate).
+// It calls validateFn for requests to the validate path.
+func newValidateTestServer(t *testing.T, validateFn http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Minimal object store for CRUD.
+	objects := map[string]map[string]interface{}{}
+
+	// Validate endpoint — delegates to the provided handler.
+	mux.HandleFunc("/api/objects/validate", validateFn)
+
+	// Object CRUD endpoint.
+	mux.HandleFunc("/api/objects/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			id := r.URL.Path[len("/api/objects/"):]
+			if obj, ok := objects[id]; ok {
+				writeJSON(w, obj)
+			} else {
+				http.NotFound(w, r)
+			}
+		case http.MethodDelete:
+			id := r.URL.Path[len("/api/objects/"):]
+			delete(objects, id)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/api/objects", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var obj map[string]interface{}
+		if err := jsonDecodeBody(r, &obj); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		id, _ := obj["id"].(string)
+		if id == "" {
+			id = "auto-id"
+			obj["id"] = id
+		}
+		objects[id] = obj
+		writeJSON(w, obj)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// TestAccRestApiObject_ValidatePath_Success tests that validate_path is called during plan
+// and a 200 response allows the plan and apply to succeed.
+func TestAccRestApiObject_ValidatePath_Success(t *testing.T) {
+	var validateCallCount int64
+
+	svr := newValidateTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&validateCallCount, 1)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "restapi" {
+  uri                  = %q
+  write_returns_object = true
+}
+
+resource "restapi_object" "test" {
+  path            = "/api/objects"
+  data            = jsonencode({ id = "val1", name = "test-validate" })
+  validate_path   = "/api/objects/validate"
+  validate_method = "POST"
+}
+`, svr.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("restapi_object.test", "id", "val1"),
+					resource.TestCheckResourceAttr("restapi_object.test", "validate_path", "/api/objects/validate"),
+					resource.TestCheckResourceAttr("restapi_object.test", "validate_method", "POST"),
+				),
+			},
+		},
+	})
+
+	if atomic.LoadInt64(&validateCallCount) == 0 {
+		t.Error("expected validate_path to be called at least once during plan, but it was not called")
+	}
+}
+
+// TestAccRestApiObject_ValidatePath_Failure tests that a non-2xx from validate_path
+// causes the plan to fail with an appropriate error.
+func TestAccRestApiObject_ValidatePath_Failure(t *testing.T) {
+	svr := newValidateTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errorMessage":"tableName is required"}`, http.StatusBadRequest)
+	})
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "restapi" {
+  uri                  = %q
+  write_returns_object = true
+}
+
+resource "restapi_object" "test" {
+  path          = "/api/objects"
+  data          = jsonencode({ id = "bad1", name = "bad-config" })
+  validate_path = "/api/objects/validate"
+}
+`, svr.URL),
+				ExpectError: regexp.MustCompile(`API pre-flight validation failed`),
+			},
+		},
+	})
+}
+
+// TestAccRestApiObject_NoValidatePath tests that omitting validate_path creates the resource normally.
+func TestAccRestApiObject_NoValidatePath(t *testing.T) {
+	svr := newValidateTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Should not be called.
+		t.Error("validate endpoint was called unexpectedly")
+		w.WriteHeader(http.StatusOK)
+	})
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "restapi" {
+  uri                  = %q
+  write_returns_object = true
+}
+
+resource "restapi_object" "test" {
+  path = "/api/objects"
+  data = jsonencode({ id = "novld1", name = "no-validate" })
+}
+`, svr.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("restapi_object.test", "id", "novld1"),
+					resource.TestCheckNoResourceAttr("restapi_object.test", "validate_path"),
+					resource.TestCheckNoResourceAttr("restapi_object.test", "validate_method"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds two new optional `restapi_object` resource attributes:

- **`validate_path`** — an endpoint to call during `terraform plan` with the object's `data`. A non-2xx response immediately fails the plan with the API's error message, surfacing configuration problems _before_ apply.
- **`validate_method`** — HTTP method for the validate call (default: `POST`).

Closes #362.

## Motivation

Many REST APIs expose a dedicated validation endpoint (e.g. `POST /resource/validate`) that performs a dry-run check without persisting anything. Without this feature, validation only surfaces at `apply` time when the API rejects the `POST`/`PUT`, which can cause partial applies where unrelated resources succeed but the invalid one fails.

## Usage

```hcl
resource "restapi_object" "example" {
  path            = "/tables"
  data            = jsonencode({ ... })
  validate_path   = "/tables/validate"
  validate_method = "POST"   # optional, defaults to POST
}
```

## Behaviour

- When `validate_path` is not set, the feature is a no-op — fully backward compatible.
- When `data` is unknown at plan time (e.g. depends on another resource), the validate call is skipped to avoid false failures.
- A non-2xx response produces a clear `API pre-flight validation failed` diagnostic that includes the validate path and the API's error body.

## Changes

| File | Change |
|---|---|
| `internal/apiclient/object.go` | Added `ValidatePath`/`ValidateMethod` to `APIObjectOpts` and `APIObject`; added `ValidateObject()` method; added `GetValidatePath()`/`GetValidateMethod()` accessors |
| `internal/provider/resource_api_object.go` | Added `validate_path`/`validate_method` schema attributes and model fields; implemented `resource.ResourceWithConfigValidators` via `validatePathValidator` |
| `internal/apiclient/object_validate_test.go` | 6 unit tests covering no-op, success, custom method, 4xx/5xx rejection, and accessors |
| `internal/provider/resource_api_object_validate_test.go` | 3 acceptance tests: success (validate called ≥1×), failure (plan error), no validate_path (no-op) |

## Test results

```
ok  github.com/Mastercard/terraform-provider-restapi/internal/apiclient
ok  github.com/Mastercard/terraform-provider-restapi/internal/provider
```

All existing tests pass. `go vet` and `gofmt` clean.