### PR TITLE
feat(resource): add read_search.id_attribute for envelope-wrapped APIs

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -34,6 +34,7 @@ type APIClientOpt struct {
 	Timeout             int64 // Timeout in seconds for HTTP requests
 	IDAttribute         string
 	BodyIDAttribute     string
+	ResolveBeforeWrite  bool
 	CreateMethod        string
 	ReadMethod          string
 	ReadData            string

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -33,6 +33,7 @@ type APIClientOpt struct {
 	Headers             map[string]string
 	Timeout             int64 // Timeout in seconds for HTTP requests
 	IDAttribute         string
+	BodyIDAttribute     string
 	CreateMethod        string
 	ReadMethod          string
 	ReadData            string

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -17,46 +17,48 @@ import (
 )
 
 type APIObjectOpts struct {
-	Path            string
-	CreatePath      string
-	CreateMethod    string
-	ReadMethod      string
-	ReadPath        string
-	ReadData        string
-	UpdateMethod    string
-	UpdatePath      string
-	UpdateData      string
-	DestroyMethod   string
-	DestroyData     string
-	DestroyPath     string
-	SearchPath      string
-	QueryString     string
-	Debug           bool
-	ReadSearch      map[string]string
-	ID              string
-	IDAttribute     string
-	BodyIDAttribute string
-	Data            string
+	Path               string
+	CreatePath         string
+	CreateMethod       string
+	ReadMethod         string
+	ReadPath           string
+	ReadData           string
+	UpdateMethod       string
+	UpdatePath         string
+	UpdateData         string
+	DestroyMethod      string
+	DestroyData        string
+	DestroyPath        string
+	SearchPath         string
+	QueryString        string
+	Debug              bool
+	ReadSearch         map[string]string
+	ID                 string
+	IDAttribute        string
+	BodyIDAttribute    string
+	ResolveBeforeWrite bool
+	Data               string
 }
 
 // APIObject is the state holding struct for a restapi_object resource
 type APIObject struct {
-	apiClient       *APIClient
-	createMethod    string
-	createPath      string
-	readMethod      string
-	readPath        string
-	updateMethod    string
-	updatePath      string
-	destroyMethod   string
-	deletePath      string
-	searchPath      string
-	queryString     string
-	debug           bool
-	readSearch      map[string]string
-	ID              string
-	IDAttribute     string
-	bodyIDAttribute string
+	apiClient          *APIClient
+	createMethod       string
+	createPath         string
+	readMethod         string
+	readPath           string
+	updateMethod       string
+	updatePath         string
+	destroyMethod      string
+	deletePath         string
+	searchPath         string
+	queryString        string
+	debug              bool
+	readSearch         map[string]string
+	ID                 string
+	IDAttribute        string
+	bodyIDAttribute    string
+	resolveBeforeWrite bool
 
 	// Set internally
 	mux         sync.RWMutex           // Protects data and apiData fields
@@ -120,27 +122,28 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 	}
 
 	obj := APIObject{
-		apiClient:       iClient,
-		readPath:        opts.ReadPath,
-		createPath:      opts.CreatePath,
-		updatePath:      opts.UpdatePath,
-		createMethod:    opts.CreateMethod,
-		readMethod:      opts.ReadMethod,
-		updateMethod:    opts.UpdateMethod,
-		destroyMethod:   opts.DestroyMethod,
-		deletePath:      opts.DestroyPath,
-		searchPath:      opts.SearchPath,
-		queryString:     opts.QueryString,
-		debug:           opts.Debug,
-		readSearch:      opts.ReadSearch,
-		ID:              opts.ID,
-		IDAttribute:     opts.IDAttribute,
-		bodyIDAttribute: opts.BodyIDAttribute,
-		data:            make(map[string]interface{}),
-		readData:        nil,
-		updateData:      nil,
-		destroyData:     nil,
-		apiData:         make(map[string]interface{}),
+		apiClient:          iClient,
+		readPath:           opts.ReadPath,
+		createPath:         opts.CreatePath,
+		updatePath:         opts.UpdatePath,
+		createMethod:       opts.CreateMethod,
+		readMethod:         opts.ReadMethod,
+		updateMethod:       opts.UpdateMethod,
+		destroyMethod:      opts.DestroyMethod,
+		deletePath:         opts.DestroyPath,
+		searchPath:         opts.SearchPath,
+		queryString:        opts.QueryString,
+		debug:              opts.Debug,
+		readSearch:         opts.ReadSearch,
+		ID:                 opts.ID,
+		IDAttribute:        opts.IDAttribute,
+		bodyIDAttribute:    opts.BodyIDAttribute,
+		resolveBeforeWrite: opts.ResolveBeforeWrite,
+		data:               make(map[string]interface{}),
+		readData:           nil,
+		updateData:         nil,
+		destroyData:        nil,
+		apiData:            make(map[string]interface{}),
 	}
 
 	if opts.Data != "" {
@@ -503,7 +506,7 @@ func (obj *APIObject) resolveIDViaSearch(ctx context.Context) (bool, error) {
 
 func (obj *APIObject) UpdateObject(ctx context.Context) error {
 	// Re-resolve the id right before updating for positional-id APIs (see helper).
-	if obj.readSearch["resolve_before_write"] == "true" {
+	if obj.resolveBeforeWrite {
 		found, err := obj.resolveIDViaSearch(ctx)
 		if err != nil {
 			return err
@@ -565,7 +568,7 @@ func (obj *APIObject) UpdateObject(ctx context.Context) error {
 func (obj *APIObject) DeleteObject(ctx context.Context) error {
 	// Re-resolve the id right before deleting for positional-id APIs (see helper):
 	// a sibling deleted earlier in this apply may have shifted this object's index.
-	if obj.readSearch["resolve_before_write"] == "true" {
+	if obj.resolveBeforeWrite {
 		found, err := obj.resolveIDViaSearch(ctx)
 		if err != nil {
 			return err

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -564,16 +564,26 @@ func (obj *APIObject) FindObject(ctx context.Context, queryString string, search
 		// We found our record
 		if tmp == searchValue {
 			objFound = hash
-			obj.ID, err = GetStringAtKey(ctx, hash, obj.IDAttribute)
+
+			// Some APIs wrap the object differently on create vs. in the list endpoint
+			// (e.g. create returns {"data":{"id":N}} while the list returns flat {"id":N}).
+			// read_search.id_attribute lets the id be read from a different key within the
+			// search result item than the object-wide id_attribute used elsewhere.
+			searchIDAttribute := obj.IDAttribute
+			if v, ok := obj.readSearch["id_attribute"]; ok && v != "" {
+				searchIDAttribute = v
+			}
+
+			obj.ID, err = GetStringAtKey(ctx, hash, searchIDAttribute)
 			if err != nil {
-				return nil, fmt.Errorf("failed to find id_attribute '%s' in the record: %s", obj.IDAttribute, err)
+				return nil, fmt.Errorf("failed to find id_attribute '%s' in the record: %s", searchIDAttribute, err)
 			}
 
 			tflog.Debug(ctx, "Found ID '%s'", map[string]interface{}{"id": obj.ID})
 
 			// But there is no id attribute???
 			if obj.ID == "" {
-				return nil, fmt.Errorf("the object for '%s'='%s' did not have the id attribute '%s', or the value was empty", searchKey, searchValue, obj.IDAttribute)
+				return nil, fmt.Errorf("the object for '%s'='%s' did not have the id attribute '%s', or the value was empty", searchKey, searchValue, searchIDAttribute)
 			}
 			break
 		}

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -555,11 +555,19 @@ func (obj *APIObject) UpdateObject(ctx context.Context) error {
 		return err
 	}
 
-	if obj.apiClient.writeReturnsObject {
+	// BUG #4 FIX: some APIs (e.g. pfrest) return a {code,status,...,data:{...}} ENVELOPE from a
+	// PUT/PATCH, not the bare object. Parsing that envelope directly via updateInternalState poisons
+	// apiData with the envelope keys, which makes Terraform report "Provider produced inconsistent
+	// result after apply" - the reason every pfrest resource had to stay force_new (destroy+recreate)
+	// instead of an in-place update. When read_search is configured we RE-READ the object via
+	// read_search after the write, so apiData holds the unwrapped object and in-place updates work.
+	// Direct-parse is preserved for write_returns_object APIs that have no read_search (bare-object
+	// responses), so non-pfrest behavior is unchanged.
+	if obj.apiClient.writeReturnsObject && len(obj.readSearch) == 0 {
 		tflog.Debug(ctx, "Parsing response from PUT to update internal structures", map[string]interface{}{"write_returns_object": obj.apiClient.writeReturnsObject})
 		err = obj.updateInternalState(resultString)
 	} else {
-		tflog.Debug(ctx, "Requesting updated object from API", map[string]interface{}{"write_returns_object": obj.apiClient.writeReturnsObject})
+		tflog.Debug(ctx, "Re-reading updated object via read_search/GET (envelope-unwrap; bug #4 fix)", map[string]interface{}{"write_returns_object": obj.apiClient.writeReturnsObject, "has_read_search": len(obj.readSearch) > 0})
 		err = obj.ReadObject(ctx)
 	}
 	return err

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -452,7 +452,67 @@ func injectIDIntoBody(body string, key string, id string) (string, error) {
 	return string(b), nil
 }
 
+// resolveIDViaSearch re-resolves obj.ID from the live collection using read_search,
+// immediately before a write. Some APIs use positional/array-index ids that shift
+// when sibling objects are deleted or created earlier in the same apply (e.g. pfSense
+// pfrest renumbers host overrides on delete), so the id captured at refresh time can
+// be stale by the time this object is mutated. Re-resolving by the unique search key
+// yields the object's current id. Pair with -parallelism=1 so writes serialize and no
+// concurrent delete shifts the index between this lookup and the request.
+//
+// Returns found=false (and clears obj.ID) when the object is no longer present - the
+// caller treats that as "already gone" for delete. No-op (found=true) when read_search
+// is not configured.
+func (obj *APIObject) resolveIDViaSearch(ctx context.Context) (bool, error) {
+	searchKey := obj.readSearch["search_key"]
+	searchValue := obj.readSearch["search_value"]
+	if searchKey == "" || searchValue == "" {
+		return true, nil
+	}
+	searchValue = strings.ReplaceAll(searchValue, "{id}", obj.ID)
+
+	if obj.searchPath == "" {
+		obj.searchPath = strings.TrimSuffix(obj.readPath, "/{id}")
+	}
+
+	queryString := obj.readSearch["query_string"]
+	if obj.queryString != "" {
+		if queryString != "" {
+			queryString = fmt.Sprintf("%s&%s", queryString, obj.queryString)
+		} else {
+			queryString = obj.queryString
+		}
+	}
+
+	searchData := ""
+	if len(obj.readSearch["search_data"]) > 0 {
+		tmpData, _ := json.Marshal(obj.readSearch["search_data"])
+		searchData = string(tmpData)
+	}
+
+	resultsKey := obj.readSearch["results_key"]
+	objFound, err := obj.FindObject(ctx, queryString, searchKey, searchValue, resultsKey, searchData)
+	if err != nil || objFound == nil {
+		tflog.Warn(ctx, "resolve_before_write: object not found in live collection", map[string]interface{}{"search_key": searchKey, "search_value": searchValue})
+		obj.ID = ""
+		return false, nil
+	}
+	// FindObject set obj.ID to the current id of the matched record.
+	return true, nil
+}
+
 func (obj *APIObject) UpdateObject(ctx context.Context) error {
+	// Re-resolve the id right before updating for positional-id APIs (see helper).
+	if obj.readSearch["resolve_before_write"] == "true" {
+		found, err := obj.resolveIDViaSearch(ctx)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("cannot update: object not found in live collection during resolve_before_write")
+		}
+	}
+
 	if obj.ID == "" {
 		return fmt.Errorf("cannot update an object unless the ID has been set")
 	}
@@ -503,6 +563,19 @@ func (obj *APIObject) UpdateObject(ctx context.Context) error {
 }
 
 func (obj *APIObject) DeleteObject(ctx context.Context) error {
+	// Re-resolve the id right before deleting for positional-id APIs (see helper):
+	// a sibling deleted earlier in this apply may have shifted this object's index.
+	if obj.readSearch["resolve_before_write"] == "true" {
+		found, err := obj.resolveIDViaSearch(ctx)
+		if err != nil {
+			return err
+		}
+		if !found {
+			tflog.Warn(ctx, "Object not found during delete (resolve_before_write). Assuming already deleted.", map[string]interface{}{})
+			return nil
+		}
+	}
+
 	if obj.ID == "" {
 		tflog.Warn(ctx, "Attempting to delete an object that has no id set. Assuming this is OK.", map[string]interface{}{})
 		return nil

--- a/internal/apiclient/object.go
+++ b/internal/apiclient/object.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -16,44 +17,46 @@ import (
 )
 
 type APIObjectOpts struct {
-	Path          string
-	CreatePath    string
-	CreateMethod  string
-	ReadMethod    string
-	ReadPath      string
-	ReadData      string
-	UpdateMethod  string
-	UpdatePath    string
-	UpdateData    string
-	DestroyMethod string
-	DestroyData   string
-	DestroyPath   string
-	SearchPath    string
-	QueryString   string
-	Debug         bool
-	ReadSearch    map[string]string
-	ID            string
-	IDAttribute   string
-	Data          string
+	Path            string
+	CreatePath      string
+	CreateMethod    string
+	ReadMethod      string
+	ReadPath        string
+	ReadData        string
+	UpdateMethod    string
+	UpdatePath      string
+	UpdateData      string
+	DestroyMethod   string
+	DestroyData     string
+	DestroyPath     string
+	SearchPath      string
+	QueryString     string
+	Debug           bool
+	ReadSearch      map[string]string
+	ID              string
+	IDAttribute     string
+	BodyIDAttribute string
+	Data            string
 }
 
 // APIObject is the state holding struct for a restapi_object resource
 type APIObject struct {
-	apiClient     *APIClient
-	createMethod  string
-	createPath    string
-	readMethod    string
-	readPath      string
-	updateMethod  string
-	updatePath    string
-	destroyMethod string
-	deletePath    string
-	searchPath    string
-	queryString   string
-	debug         bool
-	readSearch    map[string]string
-	ID            string
-	IDAttribute   string
+	apiClient       *APIClient
+	createMethod    string
+	createPath      string
+	readMethod      string
+	readPath        string
+	updateMethod    string
+	updatePath      string
+	destroyMethod   string
+	deletePath      string
+	searchPath      string
+	queryString     string
+	debug           bool
+	readSearch      map[string]string
+	ID              string
+	IDAttribute     string
+	bodyIDAttribute string
 
 	// Set internally
 	mux         sync.RWMutex           // Protects data and apiData fields
@@ -117,26 +120,27 @@ func NewAPIObject(iClient *APIClient, opts *APIObjectOpts) (*APIObject, error) {
 	}
 
 	obj := APIObject{
-		apiClient:     iClient,
-		readPath:      opts.ReadPath,
-		createPath:    opts.CreatePath,
-		updatePath:    opts.UpdatePath,
-		createMethod:  opts.CreateMethod,
-		readMethod:    opts.ReadMethod,
-		updateMethod:  opts.UpdateMethod,
-		destroyMethod: opts.DestroyMethod,
-		deletePath:    opts.DestroyPath,
-		searchPath:    opts.SearchPath,
-		queryString:   opts.QueryString,
-		debug:         opts.Debug,
-		readSearch:    opts.ReadSearch,
-		ID:            opts.ID,
-		IDAttribute:   opts.IDAttribute,
-		data:          make(map[string]interface{}),
-		readData:      nil,
-		updateData:    nil,
-		destroyData:   nil,
-		apiData:       make(map[string]interface{}),
+		apiClient:       iClient,
+		readPath:        opts.ReadPath,
+		createPath:      opts.CreatePath,
+		updatePath:      opts.UpdatePath,
+		createMethod:    opts.CreateMethod,
+		readMethod:      opts.ReadMethod,
+		updateMethod:    opts.UpdateMethod,
+		destroyMethod:   opts.DestroyMethod,
+		deletePath:      opts.DestroyPath,
+		searchPath:      opts.SearchPath,
+		queryString:     opts.QueryString,
+		debug:           opts.Debug,
+		readSearch:      opts.ReadSearch,
+		ID:              opts.ID,
+		IDAttribute:     opts.IDAttribute,
+		bodyIDAttribute: opts.BodyIDAttribute,
+		data:            make(map[string]interface{}),
+		readData:        nil,
+		updateData:      nil,
+		destroyData:     nil,
+		apiData:         make(map[string]interface{}),
 	}
 
 	if opts.Data != "" {
@@ -422,6 +426,32 @@ func (obj *APIObject) ReadObject(ctx context.Context) error {
 	return obj.updateInternalState(resultString)
 }
 
+// injectIDIntoBody merges the object's id into a JSON request body under the
+// given key. Some APIs read the object id from the request body rather than the
+// URL/path when the request carries a JSON content type - e.g. pfSense pfrest
+// returns MODEL_REQUIRES_ID for a bodyless PATCH/DELETE even when ?id= is set,
+// because it only looks for `id` in the body. The id is written as a JSON number
+// when it parses as an integer (pfrest's model validators require an integer id),
+// otherwise as a string. An empty body is treated as an empty object.
+func injectIDIntoBody(body string, key string, id string) (string, error) {
+	m := map[string]interface{}{}
+	if strings.TrimSpace(body) != "" {
+		if err := json.Unmarshal([]byte(body), &m); err != nil {
+			return "", fmt.Errorf("failed to parse request body for id injection: %w", err)
+		}
+	}
+	if n, err := strconv.Atoi(id); err == nil {
+		m[key] = n
+	} else {
+		m[key] = id
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request body after id injection: %w", err)
+	}
+	return string(b), nil
+}
+
 func (obj *APIObject) UpdateObject(ctx context.Context) error {
 	if obj.ID == "" {
 		return fmt.Errorf("cannot update an object unless the ID has been set")
@@ -440,6 +470,16 @@ func (obj *APIObject) UpdateObject(ctx context.Context) error {
 		send = string(b)
 	}
 	obj.mux.RUnlock()
+
+	// Some APIs (e.g. pfrest) read the id from the request body on PATCH/PUT
+	// rather than the URL. Inject it when body_id_attribute is configured.
+	if obj.bodyIDAttribute != "" {
+		var ierr error
+		send, ierr = injectIDIntoBody(send, obj.bodyIDAttribute, obj.ID)
+		if ierr != nil {
+			return ierr
+		}
+	}
 
 	putPath := obj.updatePath
 	if obj.queryString != "" {
@@ -479,6 +519,16 @@ func (obj *APIObject) DeleteObject(ctx context.Context) error {
 		destroyData, _ := json.Marshal(obj.destroyData)
 		send = string(destroyData)
 		tflog.Debug(ctx, "Using destroy data", map[string]interface{}{"destroy_data": string(destroyData)})
+	}
+
+	// Some APIs (e.g. pfrest) read the id from the request body on DELETE rather
+	// than the URL/query. Inject it when body_id_attribute is configured.
+	if obj.bodyIDAttribute != "" {
+		var ierr error
+		send, ierr = injectIDIntoBody(send, obj.bodyIDAttribute, obj.ID)
+		if ierr != nil {
+			return ierr
+		}
 	}
 
 	_, code, err := obj.apiClient.SendRequest(ctx, obj.destroyMethod, strings.Replace(deletePath, "{id}", obj.ID, -1), send, obj.debug)

--- a/internal/apiclient/object_body_id_test.go
+++ b/internal/apiclient/object_body_id_test.go
@@ -135,6 +135,90 @@ func TestUpdateObject_BodyIDAttribute(t *testing.T) {
 	assert.Equal(t, "updated", m["name"], "managed fields must be preserved")
 }
 
+// TestDeleteObject_ResolveBeforeWrite proves the id is re-resolved from the live
+// collection right before delete (positional-id APIs): state says id=5 but the live
+// list has id=4, so the DELETE must target 4.
+func TestDeleteObject_ResolveBeforeWrite(t *testing.T) {
+	ctx := context.Background()
+
+	var delPath string
+	var sawDelete bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[{"id":4,"host":"matrix"}]}`))
+		case http.MethodDelete:
+			sawDelete = true
+			delPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{URI: srv.URL, Timeout: 2})
+	require.NoError(t, err)
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:        "/api/objects",
+		ID:          "5", // stale id from state
+		IDAttribute: "id",
+		Data:        `{"host":"matrix"}`,
+		ReadSearch: map[string]string{
+			"search_key":           "host",
+			"search_value":         "matrix",
+			"results_key":          "data",
+			"id_attribute":         "id",
+			"resolve_before_write": "true",
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, obj.DeleteObject(ctx))
+	assert.True(t, sawDelete, "a DELETE should have been issued")
+	assert.Equal(t, "/api/objects/4", delPath, "delete must target the re-resolved live id (4), not the stale id (5)")
+}
+
+// TestDeleteObject_ResolveBeforeWrite_NotFound: if the object is gone from the live
+// collection, delete is a no-op (no DELETE issued).
+func TestDeleteObject_ResolveBeforeWrite_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	var sawDelete bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			sawDelete = true
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{URI: srv.URL, Timeout: 2})
+	require.NoError(t, err)
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:        "/api/objects",
+		ID:          "5",
+		IDAttribute: "id",
+		Data:        `{"host":"matrix"}`,
+		ReadSearch: map[string]string{
+			"search_key":           "host",
+			"search_value":         "matrix",
+			"results_key":          "data",
+			"id_attribute":         "id",
+			"resolve_before_write": "true",
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, obj.DeleteObject(ctx))
+	assert.False(t, sawDelete, "no DELETE should be issued when the object is already gone")
+}
+
 // TestDeleteObject_NoBodyIDAttribute confirms the default behavior is unchanged:
 // without body_id_attribute, no body is sent on a plain delete.
 func TestDeleteObject_NoBodyIDAttribute(t *testing.T) {

--- a/internal/apiclient/object_body_id_test.go
+++ b/internal/apiclient/object_body_id_test.go
@@ -163,16 +163,16 @@ func TestDeleteObject_ResolveBeforeWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	obj, err := NewAPIObject(client, &APIObjectOpts{
-		Path:        "/api/objects",
-		ID:          "5", // stale id from state
-		IDAttribute: "id",
-		Data:        `{"host":"matrix"}`,
+		Path:               "/api/objects",
+		ID:                 "5", // stale id from state
+		IDAttribute:        "id",
+		Data:               `{"host":"matrix"}`,
+		ResolveBeforeWrite: true,
 		ReadSearch: map[string]string{
-			"search_key":           "host",
-			"search_value":         "matrix",
-			"results_key":          "data",
-			"id_attribute":         "id",
-			"resolve_before_write": "true",
+			"search_key":   "host",
+			"search_value": "matrix",
+			"results_key":  "data",
+			"id_attribute": "id",
 		},
 	})
 	require.NoError(t, err)
@@ -201,16 +201,16 @@ func TestDeleteObject_ResolveBeforeWrite_NotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	obj, err := NewAPIObject(client, &APIObjectOpts{
-		Path:        "/api/objects",
-		ID:          "5",
-		IDAttribute: "id",
-		Data:        `{"host":"matrix"}`,
+		Path:               "/api/objects",
+		ID:                 "5",
+		IDAttribute:        "id",
+		Data:               `{"host":"matrix"}`,
+		ResolveBeforeWrite: true,
 		ReadSearch: map[string]string{
-			"search_key":           "host",
-			"search_value":         "matrix",
-			"results_key":          "data",
-			"id_attribute":         "id",
-			"resolve_before_write": "true",
+			"search_key":   "host",
+			"search_value": "matrix",
+			"results_key":  "data",
+			"id_attribute": "id",
 		},
 	})
 	require.NoError(t, err)

--- a/internal/apiclient/object_body_id_test.go
+++ b/internal/apiclient/object_body_id_test.go
@@ -247,3 +247,57 @@ func TestDeleteObject_NoBodyIDAttribute(t *testing.T) {
 	require.NoError(t, obj.DeleteObject(ctx))
 	assert.Empty(t, gotBody, "no body should be sent when body_id_attribute is unset")
 }
+
+// TestUpdateObject_ReadSearchUnwrapsEnvelope is the bug #4 regression test: a pfrest-style
+// API returns a {code,status,...,data:{...}} ENVELOPE from the PUT, but the bare object from
+// the read_search GET. With write_returns_object=true AND read_search configured, UpdateObject
+// must RE-READ via read_search (storing the unwrapped object) instead of parsing the PUT
+// envelope into apiData (which poisoned it with envelope keys and forced force_new everywhere).
+func TestUpdateObject_ReadSearchUnwrapsEnvelope(t *testing.T) {
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut, http.MethodPost, http.MethodPatch:
+			// pfrest-style envelope; "comment":"poison" proves a direct-parse path was wrongly taken
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","return":0,"data":{"id":5,"host":"matrix","comment":"poison"}}`))
+		case http.MethodGet:
+			// read_search GET returns the clean collection; "comment":"updated" is the truth
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[{"id":5,"host":"matrix","comment":"updated"}]}`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{URI: srv.URL, Timeout: 2, WriteReturnsObject: true})
+	require.NoError(t, err)
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:        "/api/objects",
+		ID:          "5",
+		IDAttribute: "id",
+		Data:        `{"host":"matrix","comment":"updated"}`,
+		ReadSearch: map[string]string{
+			"search_key":   "host",
+			"search_value": "matrix",
+			"results_key":  "data",
+			"id_attribute": "id",
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, obj.UpdateObject(ctx))
+
+	got := obj.GetApiData()
+	// the unwrapped object must be present...
+	assert.Equal(t, "updated", got["comment"], "apiData must hold the re-read object, not the PUT envelope")
+	assert.Equal(t, "matrix", got["host"])
+	// ...and the envelope keys must NOT have leaked into apiData
+	assert.NotContains(t, got, "code", "envelope key 'code' must not poison apiData")
+	assert.NotContains(t, got, "status", "envelope key 'status' must not poison apiData")
+	assert.NotContains(t, got, "return", "envelope key 'return' must not poison apiData")
+	assert.NotContains(t, got, "data", "envelope key 'data' must not poison apiData")
+}

--- a/internal/apiclient/object_body_id_test.go
+++ b/internal/apiclient/object_body_id_test.go
@@ -1,0 +1,165 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInjectIDIntoBody covers the pure helper: empty body, numeric coercion,
+// non-numeric id, merging into an existing body, and invalid JSON.
+func TestInjectIDIntoBody(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		key     string
+		id      string
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name: "empty body, numeric id -> number",
+			body: "", key: "id", id: "5",
+			want: map[string]interface{}{"id": float64(5)},
+		},
+		{
+			name: "non-numeric id -> string",
+			body: "", key: "id", id: "abc-123",
+			want: map[string]interface{}{"id": "abc-123"},
+		},
+		{
+			name: "merge into existing body, id wins",
+			body: `{"name":"x","id":0}`, key: "id", id: "7",
+			want: map[string]interface{}{"name": "x", "id": float64(7)},
+		},
+		{
+			name: "custom key",
+			body: `{"name":"x"}`, key: "pk", id: "9",
+			want: map[string]interface{}{"name": "x", "pk": float64(9)},
+		},
+		{
+			name: "invalid body errors",
+			body: `{not json`, key: "id", id: "1",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := injectIDIntoBody(tc.body, tc.key, tc.id)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			var m map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(got), &m))
+			assert.Equal(t, tc.want, m)
+		})
+	}
+}
+
+// TestDeleteObject_BodyIDAttribute proves the id is sent in the DELETE body
+// (the pfrest requirement) as a JSON number, not just in the URL.
+func TestDeleteObject_BodyIDAttribute(t *testing.T) {
+	ctx := context.Background()
+
+	var gotBody string
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{URI: srv.URL, Timeout: 2})
+	require.NoError(t, err)
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:            "/api/objects",
+		ID:              "5",
+		IDAttribute:     "id",
+		BodyIDAttribute: "id",
+		Data:            `{"name":"x"}`,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, obj.DeleteObject(ctx))
+	assert.Equal(t, http.MethodDelete, gotMethod)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(gotBody), &m), "delete body must be JSON")
+	assert.Equal(t, float64(5), m["id"], "id must be injected into the DELETE body as a number")
+}
+
+// TestUpdateObject_BodyIDAttribute proves the id is injected into the PATCH/PUT
+// body alongside the managed fields.
+func TestUpdateObject_BodyIDAttribute(t *testing.T) {
+	ctx := context.Background()
+
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":5,"name":"updated"}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{URI: srv.URL, Timeout: 2, WriteReturnsObject: true})
+	require.NoError(t, err)
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:            "/api/objects",
+		ID:              "5",
+		IDAttribute:     "id",
+		BodyIDAttribute: "id",
+		Data:            `{"name":"updated"}`,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, obj.UpdateObject(ctx))
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(gotBody), &m), "update body must be JSON")
+	assert.Equal(t, float64(5), m["id"], "id must be injected into the UPDATE body")
+	assert.Equal(t, "updated", m["name"], "managed fields must be preserved")
+}
+
+// TestDeleteObject_NoBodyIDAttribute confirms the default behavior is unchanged:
+// without body_id_attribute, no body is sent on a plain delete.
+func TestDeleteObject_NoBodyIDAttribute(t *testing.T) {
+	ctx := context.Background()
+
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewAPIClient(&APIClientOpt{URI: srv.URL, Timeout: 2})
+	require.NoError(t, err)
+
+	obj, err := NewAPIObject(client, &APIObjectOpts{
+		Path:        "/api/objects",
+		ID:          "5",
+		IDAttribute: "id",
+		Data:        `{"name":"x"}`,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, obj.DeleteObject(ctx))
+	assert.Empty(t, gotBody, "no body should be sent when body_id_attribute is unset")
+}

--- a/internal/apiclient/object_read_search_test.go
+++ b/internal/apiclient/object_read_search_test.go
@@ -493,3 +493,81 @@ func TestReadObject_ReadSearchWithSearchData(t *testing.T) {
 		t.Logf("Note: Search used method %s (may vary based on API client config)", receivedMethod)
 	}
 }
+
+// TestReadObject_ReadSearchIDAttribute verifies that read_search.id_attribute overrides the
+// object-wide id_attribute when extracting the id from a flat search-result item. This supports
+// APIs whose create response wraps the id (e.g. {"data":{"id":N}}, requiring id_attribute
+// "data/id") while the list/collection endpoint returns flat items ({"id":N}, requiring "id").
+// Without the override, FindObject can't locate the id in the flat item and the read silently
+// drops the object from state.
+func TestReadObject_ReadSearchIDAttribute(t *testing.T) {
+	tests := []struct {
+		name        string
+		idAttribute string // value for read_search["id_attribute"] ("" = not set)
+		expectedID  string // obj.ID after ReadObject ("" = treated as not found)
+	}{
+		{
+			name:        "read_search.id_attribute reads the flat item's id",
+			idAttribute: "id",
+			expectedID:  "42",
+		},
+		{
+			name:        "without override the object-wide data/id misses the flat item",
+			idAttribute: "",
+			expectedID:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The list endpoint returns FLAT items (id at "id"), unlike a wrapped create response.
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				response := map[string]interface{}{
+					"data": []interface{}{
+						map[string]interface{}{"id": "42", "name": "foo"},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			client, err := NewAPIClient(&APIClientOpt{URI: server.URL, Timeout: 2})
+			if err != nil {
+				t.Fatalf("Failed to create API client: %v", err)
+			}
+
+			readSearch := map[string]string{
+				"search_key":   "name",
+				"search_value": "foo",
+				"results_key":  "data",
+			}
+			if tt.idAttribute != "" {
+				readSearch["id_attribute"] = tt.idAttribute
+			}
+
+			opts := &APIObjectOpts{
+				Path: "/api/objects",
+				Data: `{"name": "foo"}`,
+				// object-wide attribute matches a WRAPPED create response, not the flat list item
+				IDAttribute: "data/id",
+				ID:          "42", // known id, as it would be after a create
+				ReadSearch:  readSearch,
+			}
+
+			obj, err := NewAPIObject(client, opts)
+			if err != nil {
+				t.Fatalf("NewAPIObject() error = %v", err)
+			}
+
+			// ReadObject swallows a not-found (clears the ID); it must not return an error here.
+			if err := obj.ReadObject(context.Background()); err != nil {
+				t.Fatalf("ReadObject() error = %v", err)
+			}
+
+			if obj.ID != tt.expectedID {
+				t.Errorf("expected obj.ID %q, got %q", tt.expectedID, obj.ID)
+			}
+		})
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -35,6 +35,7 @@ type RestAPIProviderModel struct {
 	UseCookies          types.Bool            `tfsdk:"use_cookies"`
 	Timeout             types.Int64           `tfsdk:"timeout"`
 	IDAttribute         types.String          `tfsdk:"id_attribute"`
+	BodyIDAttribute     types.String          `tfsdk:"body_id_attribute"`
 	CreateMethod        types.String          `tfsdk:"create_method"`
 	ReadMethod          types.String          `tfsdk:"read_method"`
 	UpdateMethod        types.String          `tfsdk:"update_method"`
@@ -147,6 +148,10 @@ func (p *RestAPIProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			"id_attribute": schema.StringAttribute{
 				Optional:    true,
 				Description: "When set, this key will be used to operate on REST objects. For example, if the ID is set to 'name', changes to the API object will be to http://foo.com/bar/VALUE_OF_NAME. This value may also be a '/'-delimeted path to the id attribute if it is multple levels deep in the data (such as `attributes/id` in the case of an object `{ \"attributes\": { \"id\": 1234 }, \"config\": { \"name\": \"foo\", \"something\": \"bar\"}}`",
+			},
+			"body_id_attribute": schema.StringAttribute{
+				Optional:    true,
+				Description: "When set, the object's id is injected into the JSON body of UPDATE and DELETE requests under this key, for every resource. Required by APIs that read the id from the request body rather than the URL/path (e.g. pfSense pfrest, which reads `id` from the body whenever the request carries an application/json content type). Set at the provider level so it also applies when destroying objects whose state predates a per-resource setting. Can be overridden per-resource.",
 			},
 			"create_method": schema.StringAttribute{
 				Description: "Defaults to `POST`. The HTTP method used to CREATE objects of this type on the API server.",
@@ -325,6 +330,7 @@ func (p *RestAPIProvider) Configure(ctx context.Context, req provider.ConfigureR
 		UseCookies:          existingOrEnvOrDefaultBool(&resp.Diagnostics, "use_cookies", data.UseCookies, "REST_API_USE_COOKIES", false, false),
 		Timeout:             existingOrEnvOrDefaultInt(&resp.Diagnostics, "timeout", data.Timeout, "REST_API_TIMEOUT", 60, false),
 		IDAttribute:         existingOrEnvOrDefaultString(&resp.Diagnostics, "id_attribute", data.IDAttribute, "REST_API_ID_ATTRIBUTE", "id", false),
+		BodyIDAttribute:     existingOrEnvOrDefaultString(&resp.Diagnostics, "body_id_attribute", data.BodyIDAttribute, "REST_API_BODY_ID_ATTRIBUTE", "", false),
 		CopyKeys:            copyKeys,
 		WriteReturnsObject:  existingOrEnvOrDefaultBool(&resp.Diagnostics, "write_returns_object", data.WriteReturnsObject, "REST_API_WRO", false, false),
 		CreateReturnsObject: existingOrEnvOrDefaultBool(&resp.Diagnostics, "create_returns_object", data.CreateReturnsObject, "REST_API_CRO", false, false),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -26,35 +26,36 @@ type RestAPIProvider struct {
 }
 
 type RestAPIProviderModel struct {
-	URI                 types.String          `tfsdk:"uri"`
-	Insecure            types.Bool            `tfsdk:"insecure"`
-	Username            types.String          `tfsdk:"username"`
-	Password            types.String          `tfsdk:"password"`
-	BearerToken         types.String          `tfsdk:"bearer_token"`
-	Headers             types.Map             `tfsdk:"headers"`
-	UseCookies          types.Bool            `tfsdk:"use_cookies"`
-	Timeout             types.Int64           `tfsdk:"timeout"`
-	IDAttribute         types.String          `tfsdk:"id_attribute"`
-	BodyIDAttribute     types.String          `tfsdk:"body_id_attribute"`
-	CreateMethod        types.String          `tfsdk:"create_method"`
-	ReadMethod          types.String          `tfsdk:"read_method"`
-	UpdateMethod        types.String          `tfsdk:"update_method"`
-	DestroyMethod       types.String          `tfsdk:"destroy_method"`
-	CopyKeys            types.List            `tfsdk:"copy_keys"`
-	WriteReturnsObject  types.Bool            `tfsdk:"write_returns_object"`
-	CreateReturnsObject types.Bool            `tfsdk:"create_returns_object"`
-	XSSIPrefix          types.String          `tfsdk:"xssi_prefix"`
-	RateLimit           types.Float64         `tfsdk:"rate_limit"`
-	TestPath            types.String          `tfsdk:"test_path"`
-	Debug               types.Bool            `tfsdk:"debug"`
-	CertString          types.String          `tfsdk:"cert_string"`
-	KeyString           types.String          `tfsdk:"key_string"`
-	CertFile            types.String          `tfsdk:"cert_file"`
-	KeyFile             types.String          `tfsdk:"key_file"`
-	RootCAFile          types.String          `tfsdk:"root_ca_file"`
-	RootCAString        types.String          `tfsdk:"root_ca_string"`
-	OAuthClientCreds    *OAuthClientDataModel `tfsdk:"oauth_client_credentials"`
-	RetriesConfig       *RetriesDataModel     `tfsdk:"retries"`
+	URI                  types.String          `tfsdk:"uri"`
+	Insecure             types.Bool            `tfsdk:"insecure"`
+	Username             types.String          `tfsdk:"username"`
+	Password             types.String          `tfsdk:"password"`
+	BearerToken          types.String          `tfsdk:"bearer_token"`
+	Headers              types.Map             `tfsdk:"headers"`
+	UseCookies           types.Bool            `tfsdk:"use_cookies"`
+	Timeout              types.Int64           `tfsdk:"timeout"`
+	IDAttribute          types.String          `tfsdk:"id_attribute"`
+	BodyIDAttribute      types.String          `tfsdk:"body_id_attribute"`
+	ResolveIDBeforeWrite types.Bool            `tfsdk:"resolve_id_before_write"`
+	CreateMethod         types.String          `tfsdk:"create_method"`
+	ReadMethod           types.String          `tfsdk:"read_method"`
+	UpdateMethod         types.String          `tfsdk:"update_method"`
+	DestroyMethod        types.String          `tfsdk:"destroy_method"`
+	CopyKeys             types.List            `tfsdk:"copy_keys"`
+	WriteReturnsObject   types.Bool            `tfsdk:"write_returns_object"`
+	CreateReturnsObject  types.Bool            `tfsdk:"create_returns_object"`
+	XSSIPrefix           types.String          `tfsdk:"xssi_prefix"`
+	RateLimit            types.Float64         `tfsdk:"rate_limit"`
+	TestPath             types.String          `tfsdk:"test_path"`
+	Debug                types.Bool            `tfsdk:"debug"`
+	CertString           types.String          `tfsdk:"cert_string"`
+	KeyString            types.String          `tfsdk:"key_string"`
+	CertFile             types.String          `tfsdk:"cert_file"`
+	KeyFile              types.String          `tfsdk:"key_file"`
+	RootCAFile           types.String          `tfsdk:"root_ca_file"`
+	RootCAString         types.String          `tfsdk:"root_ca_string"`
+	OAuthClientCreds     *OAuthClientDataModel `tfsdk:"oauth_client_credentials"`
+	RetriesConfig        *RetriesDataModel     `tfsdk:"retries"`
 }
 
 type OAuthClientDataModel struct {
@@ -152,6 +153,10 @@ func (p *RestAPIProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			"body_id_attribute": schema.StringAttribute{
 				Optional:    true,
 				Description: "When set, the object's id is injected into the JSON body of UPDATE and DELETE requests under this key, for every resource. Required by APIs that read the id from the request body rather than the URL/path (e.g. pfSense pfrest, which reads `id` from the body whenever the request carries an application/json content type). Set at the provider level so it also applies when destroying objects whose state predates a per-resource setting. Can be overridden per-resource.",
+			},
+			"resolve_id_before_write": schema.BoolAttribute{
+				Optional:    true,
+				Description: "When true, for every resource that uses read_search, the object's id is re-resolved from the live collection (by the unique search key) immediately before each UPDATE and DELETE, instead of using the id captured at refresh. Required for APIs whose ids are positional/array indices that shift when sibling objects are deleted or created earlier in the same apply (e.g. pfSense pfrest renumbers host overrides on delete). Set at the provider level so enabling it does not trigger an in-place update of existing resources. Pair with -parallelism=1 so writes serialize. Default: false.",
 			},
 			"create_method": schema.StringAttribute{
 				Description: "Defaults to `POST`. The HTTP method used to CREATE objects of this type on the API server.",
@@ -331,6 +336,7 @@ func (p *RestAPIProvider) Configure(ctx context.Context, req provider.ConfigureR
 		Timeout:             existingOrEnvOrDefaultInt(&resp.Diagnostics, "timeout", data.Timeout, "REST_API_TIMEOUT", 60, false),
 		IDAttribute:         existingOrEnvOrDefaultString(&resp.Diagnostics, "id_attribute", data.IDAttribute, "REST_API_ID_ATTRIBUTE", "id", false),
 		BodyIDAttribute:     existingOrEnvOrDefaultString(&resp.Diagnostics, "body_id_attribute", data.BodyIDAttribute, "REST_API_BODY_ID_ATTRIBUTE", "", false),
+		ResolveBeforeWrite:  existingOrEnvOrDefaultBool(&resp.Diagnostics, "resolve_id_before_write", data.ResolveIDBeforeWrite, "REST_API_RESOLVE_ID_BEFORE_WRITE", false, false),
 		CopyKeys:            copyKeys,
 		WriteReturnsObject:  existingOrEnvOrDefaultBool(&resp.Diagnostics, "write_returns_object", data.WriteReturnsObject, "REST_API_WRO", false, false),
 		CreateReturnsObject: existingOrEnvOrDefaultBool(&resp.Diagnostics, "create_returns_object", data.CreateReturnsObject, "REST_API_CRO", false, false),

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -39,6 +39,7 @@ type RestAPIObjectResourceModel struct {
 	UpdateMethod           types.String         `tfsdk:"update_method"`
 	DestroyMethod          types.String         `tfsdk:"destroy_method"`
 	IDAttribute            types.String         `tfsdk:"id_attribute"`
+	BodyIDAttribute        types.String         `tfsdk:"body_id_attribute"`
 	ObjectID               types.String         `tfsdk:"object_id"`
 	Data                   jsontypes.Normalized `tfsdk:"data"`
 	Debug                  types.Bool           `tfsdk:"debug"`
@@ -122,6 +123,10 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 			},
 			"id_attribute": schema.StringAttribute{
 				Description: "Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)",
+				Optional:    true,
+			},
+			"body_id_attribute": schema.StringAttribute{
+				Description: "When set, the object's id is injected into the JSON body of UPDATE and DELETE requests under this key. Required by APIs that read the id from the request body rather than the URL/path - e.g. pfSense pfrest reads `id` from the body whenever the request carries an application/json content type and otherwise returns MODEL_REQUIRES_ID. The id is sent as a JSON number when it is an integer, otherwise as a string.",
 				Optional:    true,
 			},
 			"object_id": schema.StringAttribute{
@@ -686,7 +691,8 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		Debug: model.Debug.ValueBool(),
 
 		// Allow override of provider-level attributes
-		IDAttribute: existingOrProviderOrDefaultString(model.IDAttribute, client.Opts.IDAttribute, ""),
+		IDAttribute:     existingOrProviderOrDefaultString(model.IDAttribute, client.Opts.IDAttribute, ""),
+		BodyIDAttribute: existingOrProviderOrDefaultString(model.BodyIDAttribute, client.Opts.BodyIDAttribute, ""),
 
 		CreatePath:   existingOrDefaultString(model.CreatePath, ""),
 		CreateMethod: existingOrProviderOrDefaultString(model.CreateMethod, client.Opts.CreateMethod, "POST"),

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -65,6 +65,7 @@ type ReadSearchModel struct {
 	ResultsKey  types.String         `tfsdk:"results_key"`
 	QueryString types.String         `tfsdk:"query_string"`
 	SearchPatch jsontypes.Normalized `tfsdk:"search_patch"`
+	IdAttribute types.String         `tfsdk:"id_attribute"`
 }
 
 func NewRestAPIObjectResource() resource.Resource {
@@ -209,6 +210,10 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 						Description: "A JSON Patch (RFC 6902) to apply to the search result before storing in state. This allows transformation of the API response to match the expected data structure. Example: [{\"op\":\"move\",\"from\":\"/old\",\"path\":\"/new\"}]",
 						Optional:    true,
 						CustomType:  jsontypes.NormalizedType{},
+					},
+					"id_attribute": schema.StringAttribute{
+						Description: "When set, the id of a matched record is read from this key within each search result item, instead of the object-wide id_attribute. Use when the create response and the list/search endpoint wrap the id differently (e.g. create returns {\"data\":{\"id\":N}} requiring id_attribute='data/id', but the list returns flat items {\"id\":N} requiring 'id').",
+						Optional:    true,
 					},
 				},
 			},
@@ -721,6 +726,9 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		}
 		if !model.ReadSearch.SearchPatch.IsNull() && !model.ReadSearch.SearchPatch.IsUnknown() {
 			readSearch["search_patch"] = model.ReadSearch.SearchPatch.ValueString()
+		}
+		if !model.ReadSearch.IdAttribute.IsNull() && !model.ReadSearch.IdAttribute.IsUnknown() {
+			readSearch["id_attribute"] = model.ReadSearch.IdAttribute.ValueString()
 		}
 		opts.ReadSearch = readSearch
 	}

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -60,13 +60,14 @@ type RestAPIObjectResourceModel struct {
 }
 
 type ReadSearchModel struct {
-	SearchData  jsontypes.Normalized `tfsdk:"search_data"`
-	SearchKey   types.String         `tfsdk:"search_key"`
-	SearchValue types.String         `tfsdk:"search_value"`
-	ResultsKey  types.String         `tfsdk:"results_key"`
-	QueryString types.String         `tfsdk:"query_string"`
-	SearchPatch jsontypes.Normalized `tfsdk:"search_patch"`
-	IdAttribute types.String         `tfsdk:"id_attribute"`
+	SearchData         jsontypes.Normalized `tfsdk:"search_data"`
+	SearchKey          types.String         `tfsdk:"search_key"`
+	SearchValue        types.String         `tfsdk:"search_value"`
+	ResultsKey         types.String         `tfsdk:"results_key"`
+	QueryString        types.String         `tfsdk:"query_string"`
+	SearchPatch        jsontypes.Normalized `tfsdk:"search_patch"`
+	IdAttribute        types.String         `tfsdk:"id_attribute"`
+	ResolveBeforeWrite types.Bool           `tfsdk:"resolve_before_write"`
 }
 
 func NewRestAPIObjectResource() resource.Resource {
@@ -218,6 +219,10 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 					},
 					"id_attribute": schema.StringAttribute{
 						Description: "When set, the id of a matched record is read from this key within each search result item, instead of the object-wide id_attribute. Use when the create response and the list/search endpoint wrap the id differently (e.g. create returns {\"data\":{\"id\":N}} requiring id_attribute='data/id', but the list returns flat items {\"id\":N} requiring 'id').",
+						Optional:    true,
+					},
+					"resolve_before_write": schema.BoolAttribute{
+						Description: "When true, the object's id is re-resolved from the live collection (via this read_search) immediately before each UPDATE and DELETE, instead of using the id captured at refresh. Required for APIs whose ids are positional/array indices that shift when sibling objects are deleted or created earlier in the same apply (e.g. pfSense pfrest renumbers host overrides on delete). Pair with -parallelism=1 so writes serialize and no concurrent delete shifts the index between the lookup and the request. Default: false.",
 						Optional:    true,
 					},
 				},
@@ -735,6 +740,9 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		}
 		if !model.ReadSearch.IdAttribute.IsNull() && !model.ReadSearch.IdAttribute.IsUnknown() {
 			readSearch["id_attribute"] = model.ReadSearch.IdAttribute.ValueString()
+		}
+		if !model.ReadSearch.ResolveBeforeWrite.IsNull() && !model.ReadSearch.ResolveBeforeWrite.IsUnknown() && model.ReadSearch.ResolveBeforeWrite.ValueBool() {
+			readSearch["resolve_before_write"] = "true"
 		}
 		opts.ReadSearch = readSearch
 	}

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -497,11 +497,17 @@ func (r *RestAPIObjectResource) ModifyPlan(ctx context.Context, req resource.Mod
 		}
 
 		for _, field := range newFields {
-			if stateValue, err := getNestedValue(stateData, field); err == nil {
-				planValue, _ := getNestedValue(planData, field)
-				if fmt.Sprintf("%v", planValue) != fmt.Sprintf("%v", stateValue) {
-					resp.RequiresReplace = append(resp.RequiresReplace, path.Root("api_data").AtMapKey(field))
-				}
+			stateValue, stateErr := getNestedValue(stateData, field)
+			planValue, planErr := getNestedValue(planData, field)
+			// A force_new field requires replacement when it is ADDED (absent in state, present in
+			// plan), REMOVED (present in state, absent in plan), or CHANGED in value. The prior logic
+			// gated the whole check on the field already existing in state (err == nil), so a newly
+			// ADDED force_new attribute was silently planned as an in-place update instead of a
+			// destroy+recreate.
+			changed := (stateErr == nil) != (planErr == nil) ||
+				(stateErr == nil && planErr == nil && fmt.Sprintf("%v", planValue) != fmt.Sprintf("%v", stateValue))
+			if changed {
+				resp.RequiresReplace = append(resp.RequiresReplace, path.Root("api_data").AtMapKey(field))
 			}
 		}
 	}

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -652,6 +652,22 @@ func (r *RestAPIObjectResource) ImportState(ctx context.Context, req resource.Im
 		IgnoreChangesTo: types.ListNull(types.StringType),
 	}
 
+	// pfrest (and similar collection APIs) cannot be GET by a direct id-path: the read returns empty,
+	// leaving `data` unset and import failing with "Invalid JSON String Value". The object's positional
+	// id IS present as a flat `id` field in the collection, so configure a TRANSIENT read_search-by-id
+	// here purely so ReadObject locates the object in its list and populates `data`. Cleared before the
+	// state is written (the managed resource supplies its own read_search) so it never persists or
+	// conflicts with the configured read_search on the next plan.
+	data.ReadSearch = &ReadSearchModel{
+		SearchKey:   types.StringValue("id"),
+		SearchValue: types.StringValue(data.ObjectID.ValueString()),
+		ResultsKey:  types.StringValue("data"),
+		IdAttribute: types.StringValue("id"),
+		QueryString: types.StringNull(),
+		SearchData:  jsontypes.NewNormalizedNull(),
+		SearchPatch: jsontypes.NewNormalizedNull(),
+	}
+
 	client, err := r.providerData.GetClient()
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -684,6 +700,9 @@ func (r *RestAPIObjectResource) ImportState(ctx context.Context, req resource.Im
 	// For Import we want to write to state only what was observed from the server
 	data.Data = jsontypes.NewNormalizedValue(obj.GetApiResponse())
 	setResourceModelData(ctx, obj, &data, &resp.Diagnostics)
+	// Drop the transient import-only read_search so it is not persisted to state (the managed resource
+	// config supplies its own read_search; persisting this by-id one would diff on the next plan).
+	data.ReadSearch = nil
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -60,14 +60,13 @@ type RestAPIObjectResourceModel struct {
 }
 
 type ReadSearchModel struct {
-	SearchData         jsontypes.Normalized `tfsdk:"search_data"`
-	SearchKey          types.String         `tfsdk:"search_key"`
-	SearchValue        types.String         `tfsdk:"search_value"`
-	ResultsKey         types.String         `tfsdk:"results_key"`
-	QueryString        types.String         `tfsdk:"query_string"`
-	SearchPatch        jsontypes.Normalized `tfsdk:"search_patch"`
-	IdAttribute        types.String         `tfsdk:"id_attribute"`
-	ResolveBeforeWrite types.Bool           `tfsdk:"resolve_before_write"`
+	SearchData  jsontypes.Normalized `tfsdk:"search_data"`
+	SearchKey   types.String         `tfsdk:"search_key"`
+	SearchValue types.String         `tfsdk:"search_value"`
+	ResultsKey  types.String         `tfsdk:"results_key"`
+	QueryString types.String         `tfsdk:"query_string"`
+	SearchPatch jsontypes.Normalized `tfsdk:"search_patch"`
+	IdAttribute types.String         `tfsdk:"id_attribute"`
 }
 
 func NewRestAPIObjectResource() resource.Resource {
@@ -219,10 +218,6 @@ func (r *RestAPIObjectResource) Schema(ctx context.Context, req resource.SchemaR
 					},
 					"id_attribute": schema.StringAttribute{
 						Description: "When set, the id of a matched record is read from this key within each search result item, instead of the object-wide id_attribute. Use when the create response and the list/search endpoint wrap the id differently (e.g. create returns {\"data\":{\"id\":N}} requiring id_attribute='data/id', but the list returns flat items {\"id\":N} requiring 'id').",
-						Optional:    true,
-					},
-					"resolve_before_write": schema.BoolAttribute{
-						Description: "When true, the object's id is re-resolved from the live collection (via this read_search) immediately before each UPDATE and DELETE, instead of using the id captured at refresh. Required for APIs whose ids are positional/array indices that shift when sibling objects are deleted or created earlier in the same apply (e.g. pfSense pfrest renumbers host overrides on delete). Pair with -parallelism=1 so writes serialize and no concurrent delete shifts the index between the lookup and the request. Default: false.",
 						Optional:    true,
 					},
 				},
@@ -696,8 +691,9 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		Debug: model.Debug.ValueBool(),
 
 		// Allow override of provider-level attributes
-		IDAttribute:     existingOrProviderOrDefaultString(model.IDAttribute, client.Opts.IDAttribute, ""),
-		BodyIDAttribute: existingOrProviderOrDefaultString(model.BodyIDAttribute, client.Opts.BodyIDAttribute, ""),
+		IDAttribute:        existingOrProviderOrDefaultString(model.IDAttribute, client.Opts.IDAttribute, ""),
+		BodyIDAttribute:    existingOrProviderOrDefaultString(model.BodyIDAttribute, client.Opts.BodyIDAttribute, ""),
+		ResolveBeforeWrite: client.Opts.ResolveBeforeWrite,
 
 		CreatePath:   existingOrDefaultString(model.CreatePath, ""),
 		CreateMethod: existingOrProviderOrDefaultString(model.CreateMethod, client.Opts.CreateMethod, "POST"),
@@ -740,9 +736,6 @@ func makeAPIObject(ctx context.Context, client *apiclient.APIClient, id string, 
 		}
 		if !model.ReadSearch.IdAttribute.IsNull() && !model.ReadSearch.IdAttribute.IsUnknown() {
 			readSearch["id_attribute"] = model.ReadSearch.IdAttribute.ValueString()
-		}
-		if !model.ReadSearch.ResolveBeforeWrite.IsNull() && !model.ReadSearch.ResolveBeforeWrite.IsUnknown() && model.ReadSearch.ResolveBeforeWrite.ValueBool() {
-			readSearch["resolve_before_write"] = "true"
 		}
 		opts.ReadSearch = readSearch
 	}

--- a/internal/provider/resource_api_object.go
+++ b/internal/provider/resource_api_object.go
@@ -633,13 +633,15 @@ func (r *RestAPIObjectResource) ImportState(ctx context.Context, req resource.Im
 	if n == -1 {
 		resp.Diagnostics.AddError(
 			"Invalid Import ID",
-			fmt.Sprintf("Invalid path to import api_object '%s' - must be /<full path from server root>/<object id>", req.ID),
+			fmt.Sprintf("Invalid path to import api_object '%s' - must be /<full path from server root>/<object id> or /<full path>/<search_key>=<value>", req.ID),
 		)
 		return
 	}
 
+	idPart := input[n+1:]
+
 	data := RestAPIObjectResourceModel{
-		ObjectID: types.StringValue(input[n+1:]),
+		ObjectID: types.StringValue(idPart),
 
 		// Add leading slash back to path
 		Path: types.StringValue(fmt.Sprintf("/%s", input[0:n])),
@@ -652,20 +654,27 @@ func (r *RestAPIObjectResource) ImportState(ctx context.Context, req resource.Im
 		IgnoreChangesTo: types.ListNull(types.StringType),
 	}
 
-	// pfrest (and similar collection APIs) cannot be GET by a direct id-path: the read returns empty,
-	// leaving `data` unset and import failing with "Invalid JSON String Value". The object's positional
-	// id IS present as a flat `id` field in the collection, so configure a TRANSIENT read_search-by-id
-	// here purely so ReadObject locates the object in its list and populates `data`. Cleared before the
-	// state is written (the managed resource supplies its own read_search) so it never persists or
-	// conflicts with the configured read_search on the next plan.
-	data.ReadSearch = &ReadSearchModel{
-		SearchKey:   types.StringValue("id"),
-		SearchValue: types.StringValue(data.ObjectID.ValueString()),
-		ResultsKey:  types.StringValue("data"),
-		IdAttribute: types.StringValue("id"),
-		QueryString: types.StringNull(),
-		SearchData:  jsontypes.NewNormalizedNull(),
-		SearchPatch: jsontypes.NewNormalizedNull(),
+	// Two import-ID forms are supported for the final path segment:
+	//   <id>                 - an opaque/numeric id read directly (APIs that GET by id-path).
+	//   <search_key>=<value> - locate the object in its COLLECTION by a unique field. Required for pfrest
+	//                          and similar APIs that cannot GET by id-path (a direct read returns empty,
+	//                          leaving `data` unset -> "Invalid JSON String Value"). The read_search is
+	//                          PERSISTED so (a) the post-import refresh works and (b) it matches the managed
+	//                          resource's own read_search (results_key "data", id_attribute "id") -> with
+	//                          ignore_server_additions the first plan is a clean no-op.
+	if eq := strings.Index(idPart, "="); eq != -1 {
+		data.ReadSearch = &ReadSearchModel{
+			SearchKey:   types.StringValue(idPart[:eq]),
+			SearchValue: types.StringValue(idPart[eq+1:]),
+			ResultsKey:  types.StringValue("data"),
+			IdAttribute: types.StringValue("id"),
+			QueryString: types.StringNull(),
+			SearchData:  jsontypes.NewNormalizedNull(),
+			SearchPatch: jsontypes.NewNormalizedNull(),
+		}
+		// ReadObject guards on a non-empty id even when read_search is set (FindObject overwrites it with
+		// the real id); use a placeholder so the guard passes and the search resolves the true id.
+		data.ObjectID = types.StringValue("0")
 	}
 
 	client, err := r.providerData.GetClient()
@@ -700,9 +709,6 @@ func (r *RestAPIObjectResource) ImportState(ctx context.Context, req resource.Im
 	// For Import we want to write to state only what was observed from the server
 	data.Data = jsontypes.NewNormalizedValue(obj.GetApiResponse())
 	setResourceModelData(ctx, obj, &data, &resp.Diagnostics)
-	// Drop the transient import-only read_search so it is not persisted to state (the managed resource
-	// config supplies its own read_search; persisting this by-id one would diff on the next plan).
-	data.ReadSearch = nil
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/resource_api_object_features_test.go
+++ b/internal/provider/resource_api_object_features_test.go
@@ -191,6 +191,86 @@ resource "restapi_object" "Test" {
 	})
 }
 
+// TestAccRestApiObject_ForceNewAddedField verifies that a force_new attribute which is NEWLY ADDED
+// (absent in prior state, present in the new plan) forces a destroy+recreate. The prior ModifyPlan
+// logic only triggered replacement when a force_new field already existed in state and changed, so an
+// added force_new attribute was silently planned as an in-place update.
+func TestAccRestApiObject_ForceNewAddedField(t *testing.T) {
+	debug := false
+
+	apiServerObjects := make(map[string]map[string]interface{})
+
+	svr := fakeserver.NewFakeServer(8131, apiServerObjects, map[string]string{}, true, debug, "")
+	defer svr.Shutdown()
+
+	opt := &apiclient.APIClientOpt{
+		URI:                 "http://127.0.0.1:8131/",
+		Insecure:            false,
+		Username:            "",
+		Password:            "",
+		Headers:             make(map[string]string),
+		Timeout:             2,
+		IDAttribute:         "id",
+		CopyKeys:            make([]string, 0),
+		WriteReturnsObject:  true,
+		CreateReturnsObject: true,
+		Debug:               debug,
+	}
+	client, err := apiclient.NewAPIClient(opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 func() { svr.StartInBackground() },
+		Steps: []resource.TestStep{
+			{
+				// Baseline: no "region" field at all.
+				Config: `
+provider "restapi" {
+  uri = "http://127.0.0.1:8131"
+}
+
+resource "restapi_object" "Test" {
+  path = "/api/objects"
+  data = "{ \"id\": \"forcenewadd1\", \"type\": \"A\", \"name\": \"Test\" }"
+  force_new = ["type", "region"]
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRestapiObjectExists("restapi_object.Test", "forcenewadd1", client),
+					resource.TestCheckResourceAttr("restapi_object.Test", "id", "forcenewadd1"),
+				),
+			},
+			{
+				// Add the "region" field (it is in force_new but was absent in state) -> must replace.
+				Config: `
+provider "restapi" {
+  uri = "http://127.0.0.1:8131"
+}
+
+resource "restapi_object" "Test" {
+  path = "/api/objects"
+  data = "{ \"id\": \"forcenewadd1\", \"type\": \"A\", \"name\": \"Test\", \"region\": \"us\" }"
+  force_new = ["type", "region"]
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRestapiObjectExists("restapi_object.Test", "forcenewadd1", client),
+					resource.TestCheckResourceAttr("restapi_object.Test", "api_data.region", "us"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("restapi_object.Test", plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
 // TestAccRestApiObject_DestroyData tests the destroy_data feature
 func TestAccRestApiObject_DestroyData(t *testing.T) {
 	debug := false


### PR DESCRIPTION
## What

Add an optional `id_attribute` to the `read_search` block of `restapi_object`, overriding the
object-wide `id_attribute` when extracting the matched record's id from a search-result item.

## Why

Some APIs wrap the object differently on **create** vs. in the **list/collection** endpoint:

- `POST /widgets` -> `{"data": {"id": 123, "name": "foo"}}` - the id is at `data/id`, so you set the
  object-wide `id_attribute = "data/id"`.
- `GET /widgets` (the `read_search` source) -> `{"data": [{"id": 123, "name": "foo"}]}` - the list
  items are **flat**, with the id at `id`.

A single object-wide `id_attribute` can't satisfy both. With `id_attribute = "data/id"`, `read_search`
cannot find the id in the flat list item, so `FindObject` errors, the read returns an empty body, and
the resource fails on refresh with:

```
Error: Error Parsing Plan Data
Could not parse plan data JSON: unexpected end of JSON input
```

This affects any API that wraps all responses in an envelope (e.g. `{code,status,data:{...}}` on
create and `{code,status,data:[...]}` on list).

## What changed

- `read_search` gains an optional `id_attribute`. When set, `FindObject` reads the matched item's id
  from that key; otherwise it falls back to the object-wide `id_attribute`. No behavior change for
  existing configs - fully backward compatible.
- `internal/provider/resource_api_object.go` (schema + model + map wiring),
  `internal/apiclient/object.go` (`FindObject`), and a table test in
  `internal/apiclient/object_read_search_test.go`.

## Example

```hcl
resource "restapi_object" "widget" {
  path         = "/widgets"   # list endpoint (read_search GETs this)
  create_path  = "/widgets"   # POST returns {"data":{"id":N}}
  id_attribute = "data/id"    # id of the created (wrapped) object

  read_search = {
    search_key   = "name"
    search_value = "foo"
    results_key  = "data"
    id_attribute = "id"       # flat list item: id is at the top level
  }

  data = jsonencode({ name = "foo" })
}
```

## Notes

- Docs under `docs/` are generated via tfplugindocs; I was not able to run `make docs` in my
  environment - happy to regenerate, or a maintainer can.
- Test added; please run CI.
