### PR TITLE
docs: clarify JSON-only request body + DELETE semantics + 415 troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ There are a few requirements about how the API must work for this provider to be
 * Objects live under a distinct path such that for the path `/api/v1/things`...
     * POST on `/api/v1/things` creates a new object
     * GET, PUT and DELETE on `/api/v1/things/{id}` manages an existing object
+* **Request and response bodies are JSON.** The `data` field on `restapi_object` is parsed as JSON internally and the body sent to the API is always JSON-encoded — even if you change `Content-Type` to something else via the provider's `headers` map. APIs that require a different request body format (e.g. `application/x-www-form-urlencoded`, multipart) are not supported by this provider; see [Alternatives](#alternatives) below.
+* **The API must accept the same DELETE semantics on every applied resource.** This provider issues `DELETE` on destroy by default (overridable per-resource via `destroy_method`). If the API rejects DELETE for any reason — e.g. server-side disabled — Terraform's destroy step will fail and block applies on any state change that triggers a recreate. You can work around this with `destroy_method = "POST"` (or any method the API does accept) plus a `destroy_data` body that the API treats as a no-op, but the cleanest approach for DELETE-disabled APIs is to model the resource with `null_resource` + `local-exec` instead.
 
 Have a look at the [examples directory](examples) for some use cases.
+
+### Alternatives
 
 While this provider can be a good approach if the above semantics are met, it isn't the best option for all cases. There are a few other providers that have been recommended by the community in discussion of issues:
 * [hashicorp/http](https://registry.terraform.io/providers/hashicorp/http/latest/docs) - a data source provider that can make a request and provide raw access to the response headers and payload
@@ -67,6 +71,7 @@ Here are some tips for troubleshooting that may be helpful...
 
 If an unexpected error occurs, enable debug log and review the output:
 * Does the API return an odd HTTP response code? This is common for bad requests to the API. Look closely at the HTTP request details.
+* `HTTP 415 unsupported media type` on create/update? The API likely doesn't accept JSON request bodies. This provider always sends JSON regardless of the `Content-Type` header set via `headers` — see the JSON-body requirement under [About This Provider](#about-this-provider). For APIs that require `application/x-www-form-urlencoded` or other non-JSON bodies, model the resource with `null_resource` + `local-exec` (or one of the alternative providers listed below) instead.
 * Does an unexpected golang 'unmarshaling' error occur? Take a look at the debug log and see if anything other than a hash (for resources) or an array (for the datasource) is being returned. For example, the provider cannot cope with cases where a JSON object is requested, but an array of JSON objects is returned.
 
 &nbsp;


### PR DESCRIPTION
## Summary

Two implicit constraints in this provider bite first-time users when their API doesn't match. This PR documents both in the README + adds one targeted troubleshooting bullet, with no code changes.

## Background

I just spent a non-trivial amount of debugging time discovering that:

1. **The `data` field is always re-marshaled to JSON before transmission**, regardless of any `Content-Type` header override via the provider's `headers` map. This is anchored in current source: `internal/apiclient/object.go` parses `data` with `json.Unmarshal` into `map[string]interface{}`, then `CreateObject`/`UpdateObject`/etc. each `json.Marshal` it back before calling `SendRequest`. The wire `Content-Type` can change, but the wire body is always JSON. **Symptom for users with non-JSON APIs: `HTTP 415 unsupported media type`** on create/update.
2. **The API must accept DELETE on every resource that may ever be recreated.** This is implied by `destroy_method` defaulting to `DELETE`, but isn't called out — and it bites apps whose backend explicitly blocks DELETE (server returns 405).

Both constraints are real and worth surfacing before a user picks this provider for an incompatible API.

## Changes

- Two new bullets under \"About This Provider → requirements\" stating the JSON-body and DELETE constraints explicitly.
- `### Alternatives` heading on the existing alternative-providers paragraph (so the new bullets can deep-link to it).
- One new bullet in `Troubleshooting → Debug log` specifically for the HTTP 415 case, with the recommended workaround (`null_resource` + `local-exec` or one of the alternative providers).

## Why README and not the schema description

`docs/resources/object.md` is autogenerated by tfplugindocs from the Go schema strings. The README is the right place for cross-cutting constraints + decision-time guidance.

## Acknowledging the bigger picture

This isn't a bug or a feature request — the provider is intentionally a "wrapped cURL with JSON support" (per the existing README intro). The clarifications just save future users a debugging cycle when their API isn't JSON-shaped.

Happy to adjust wording or scope down further if you'd prefer something tighter.