### PR TITLE
Pin release workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/gpginfo.yaml
+++ b/.github/workflows/gpginfo.yaml
@@ -7,7 +7,7 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba # v2.1.0
         env:
           # These secrets will need to be configured for the repository:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,28 +25,28 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true
       -
         name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.0.0
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
-          version: latest
+          version: v2.16.0
           args: release --parallelism 2 --clean --timeout 1h --release-notes .release_info.md
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
## Summary

- pins release/signing workflow actions to immutable commit SHAs
- replaces the mutable GoReleaser `latest` binary selector with `v2.16.0`
- keeps version comments beside each SHA for maintainability

Fixes #368.

## Security rationale

The release workflows expose GPG signing material and release publishing context. Mutable action refs can be retargeted upstream and are resolved by GitHub Actions at workflow runtime. Pinning to full commit SHAs prevents tag retargeting from changing the code executed by these privileged jobs.

## Validation

- Parsed `.github/workflows/release.yaml` and `.github/workflows/gpginfo.yaml` with Ruby YAML parser
- Ran `git diff --check`
